### PR TITLE
feat(skill): 添加.claude目录，适配claude code

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,61 @@
+---
+description: Public API, Card/Config split, and module boundaries for agent-core-java.
+language: english
+paths:
+  - "src/main/java/com/openjiuwen/**/*.java"
+  - "src/test/java/com/openjiuwen/**/*.java"
+---
+
+# Architecture Rules
+
+## Public API
+
+- Treat public classes/methods documented in Javadoc, examples, and
+  README snippets as public API.
+- Keep public API changes additive: preserve names and parameter order.
+- Prefer overloaded methods or `Optional` parameters for new optional
+  parameters, not changing existing signatures.
+- Compatibility tests (`*CompatibilityTest.java`) enforce Java-Python
+  parity; do not break them without explicit justification.
+
+## Card / Config Split
+
+**Design intent**: Cards are static metadata, serializable and
+transportable; Configs are runtime objects holding resources and
+state. Cards cross process boundaries (e.g., A2A protocol); Configs
+remain process-local.
+
+**When to add a new Card type**:
+- Metadata needs to cross process/service boundaries
+- Metadata needs to be persisted or stored
+- Capabilities need to be discovered and registered at runtime
+
+**Anti-patterns**:
+- Putting `sessionId`, `runner`, or other runtime data in a Card
+- Defining static description fields in a Config (should be in a Card)
+- Injecting dynamic computation into a Card's `toMap()` method
+
+## Module Boundaries
+
+| Package | Responsibility |
+|---|---|
+| `core.singleagent` | Current single-agent API. `BaseAgent` → `ReActAgent` is primary; `ControllerAgent` is event-driven variant |
+| `harness` | Deep agent framework: prompts, rails, tools, factory/config, workspace. Changes here are tightly coupled — inspect tests |
+| `agentteams` | Leader-Teammate team framework. `TeamAgent` serves both roles (switched by `TeamRole`). `CoordinatorLoop` only wakes up; business logic in `EventDispatcher` + team tools |
+| `core.workflow` | DAG workflow engine. `Workflow` builds graph of `WorkflowComponent` instances, compiles to `PregelGraph` |
+| `core.runner` | Singleton runtime facade. `ResourceMgr` manages `AgentMgr`, `ToolMgr`, `ModelMgr`, `WorkflowMgr`, `TagMgr`. Use stable IDs, keep tests isolated |
+| `core.sysop` | System operations (shell, fs, code). Security-sensitive — preserve validation around paths, shell, approvals, interrupts |
+| `core.memory` | `LongTermMemory` interface. Graph memory + lite memory + external providers |
+| `core.retrieval` | `KnowledgeBase` base class. Retrievers, embedding, indexing implementations |
+| `autoharness` | CI/CD pipelines. `AutoHarnessOrchestrator` entry point. Security-sensitive |
+| `agentevolving` | RL training: `Trainer`, `BaseOptimizer`, `BaseEvaluator`, checkpointing |
+| `spi` | Storage backend SPI: `BaseKVStore` / `BaseVectorStore` / `BaseObjectStorageClient` |
+| `extensions` | Optional integrations (A2A, Redis, sandbox, MQ, vendor adapters). Must not create circular deps with core |
+
+**Rule**: Before changing a module, inspect the touched class, its
+public surface, and nearby tests/examples. Do not refactor unrelated
+areas opportunistically.
+
+**Rule**: `TeamAgent` is a single implementation serving both Leader
+and Teammate roles (switched by `TeamRole`). Do not split into two
+classes.

--- a/.claude/rules/coding-standard.md
+++ b/.claude/rules/coding-standard.md
@@ -1,0 +1,88 @@
+# Java Coding Standards
+
+Huawei CodeArts Check Java rule set. 124 base rules (`G.*`) + extended rules (`X.*`). Security rules (marked `[S]`) carry higher risk and should be prioritized. For detailed descriptions and OK/BAD code examples, use `/coding-standard`.
+
+## Quick Self-Check (covers 80% of common issues)
+
+1. `G.NAM.03` Class/enum/interface: PascalCase
+2. `G.NAM.04` Method names: camelCase
+3. `G.NAM.05` Constants: ALL_UPPERCASE with underscores
+4. `G.ERR.01` No empty catch blocks
+5. `G.ERR.02` No catching Throwable/Exception/RuntimeException directly
+6. `G.ERR.06` [S] Pass original exception as cause when re-throwing
+7. `G.FMT.07` Avoid empty blocks; add comment when necessary
+8. `G.LOG.01` Use SLF4J facade, not Log4j/Logback directly
+9. `G.LOG.02` Logger: private static final
+10. `G.OBJ.06` Override hashCode when overriding equals
+11. `G.PRM.05` No unnecessary objects
+12. `G.CON.07` New threads must specify a name
+
+## Scenario → Rules
+
+| Scenario | Rules |
+|---|---|
+| Service/business classes | `G.OBJ.01-08`, `G.NAM.03/04`, `G.CMT.01/03` |
+| Exception handling | `G.ERR.01-09`, `G.CTL.03` |
+| Multi-threaded code | `G.CON.01/05-12`, `G.TYP.03`, `X.CON.01-06` |
+| Logging | `G.LOG.01-04` |
+| Collections/generics | `G.COL.02-04`, `G.PRM.01`, `X.COL.01-04` |
+| IO operations | `G.PRM.07`, `G.FIO.01-04`, `G.TYP.09` |
+| Method signatures | `G.MET.01-07`, `G.NAM.04`, `G.ERR.07` |
+| Constants/enums | `G.NAM.05`, `G.DCL.04/05`, `G.FMT.15` |
+| Overriding equals | `G.OBJ.06`, `G.EXP.04` |
+| Serializable classes | `G.SER.01/02/04/05/07` |
+| Tests | `X.TST.01-06` |
+| SQL/database | `X.SQL.01-07` |
+| Code Review | Self-Check List first, then by scenario |
+
+## All Rules
+
+### G.CMT Comments — `G.CMT.01` Public/protected must have Javadoc · `02` Top-level class Javadoc: description+date/version · `03` Method Javadoc: description+@param/@return/@throws · `04` No empty formatted method header comments · `05` File header: copyright/license · `06` Blank line/space between comments and code · `07` No TODO/FIXME in production code
+
+### G.COL Collections — `G.COL.02` Prefer generic collections over arrays · `03` Use bounds to restrict generic types · `04` No remove/add inside foreach
+
+### G.CON Concurrency — `G.CON.01` [S] Avoid synchronization pitfalls (no Lock/Condition as synchronized lock, no class objects as lock, no reusable object locks, no public lock objects, no instance locks for static data) · `05` [S] No overriding thread-safe with non-thread-safe · `06` Use concurrency utils, not wait/notify · `07` New threads must have a name · `08` Use setUncaughtExceptionHandler · `09` No relying on thread scheduler/priority/yield · `10` Handle thread interruption cooperatively · `11` [S] No Thread.stop() · `12` Use thread pools, not uncontrolled new threads
+
+### G.CTL Control Flow — `G.CTL.01` No assignments in control conditions · `02` else-if chains need else · `03` switch needs default · `05` No modifying loop variable in body
+
+### G.DCL Declarations — `G.DCL.01` One variable per line · `02` Declare local variables close to first use · `03` No C-style array declarations · `04` No ordinal() for enum ordering · `05` No mutable constants
+
+### G.ERR Exceptions — `G.ERR.01` No empty catch · `02` No catching Throwable/Exception/RuntimeException · `03` No catching pre-checkable RuntimeExceptions · `04` [S] No leaking sensitive info via exceptions · `05` Exceptions match abstraction level · `06` [S] Pass original as cause when re-throwing · `07` Max 5 exceptions per method; document in @throws · `08` [S] No return/break/continue/throw in finally · `09` [S] No System.exit() · `10` Eliminate unchecked; no SuppressWarning on class · `11` Log GeneralSecurityException
+
+### G.EXP Expressions — `G.EXP.01` No double assignment in one expression · `02` Use parentheses for clarity · `03` Ternary operands same type · `04` Left varies, right constant; equals for String · `06` [S] No assert in code
+
+### G.EDV XML Security — `G.EDV.05` [S] Prevent XXE attacks when parsing external XML · `06` [S] Prevent XML Entity Expansion attacks · `07` [S] No unsafe XSLT transformations
+
+### G.FIO File IO — `G.FIO.01` [S] Validate+normalize external file paths · `02` [S] Security-check ZipInputStream entries before extraction · `03` [S] Use int return for single byte/char reads from streams · `04` [S] Prevent external process blocking on IO streams
+
+### G.FMT Formatting — `G.FMT.01` UTF-8 encoding · `02` Source file structure: copyright/package/import/class · `03` Import order: static→Android→Huawei→commercial→open-source→net/org→Java · `04` Class member order: class vars→static init→instance vars→instance init→constructors→methods · `05` Braces required · `06` Left brace end-of-line, right brace new line · `07` Avoid empty blocks · `08` 4-space indentation, no tabs · `09` One statement per line · `10` Line width ≤120 chars · `11` Line break before operator · `12` Reduce blank lines · `13` Spaces highlight keywords · `14` No vertical alignment spaces · `15` Enum: comma-separated · `16` Fall-through must be commented · `17` Each annotation own line · `18` Comment indentation matches code · `19` Modifiers in JLS order · `20` Long uses L suffix
+
+### G.LOG Logging — `G.LOG.01` SLF4J facade · `02` Logger: private static final · `03` Leveled (DEBUG/INFO/WARN/ERROR) · `04` No Chinese in logs for non-Chinese-only products
+
+### G.MET Methods — `G.MET.01` Short methods; ≤5 params · `03` No params as temp vars · `04` Varargs with caution · `05` Return empty collection, not null · `06` Optional instead of null · `07` [S] No ignoring return values
+
+### G.NAM Naming — `G.NAM.01` Identifiers ≤64 chars · `02` Packages lowercase dot-separated · `03` Class/enum/interface: PascalCase · `04` Methods: camelCase · `05` Constants: ALL_UPPERCASE · `06` Variables: camelCase · `07` No negative boolean names · `08` Booleans start with true/false verb
+
+### G.OBJ Classes — `G.OBJ.01` No public non-final fields · `02` No overridable calls in constructor · `03` Reuse constructors · `04` No name reuse/shadowing · `05` No primitive/wrapper same-name overloads · `06` hashCode with equals · `07` @Override required on override methods · `08` Singleton correctly · `09` [S] Use class name for static method calls · `10` Remove redundant interface modifiers
+
+### G.OTH Other — `G.OTH.01` [S] Use cryptographically secure random in security contexts · `02` [S] Use SSLSocket not Socket · `03` Delete unused code/imports · `04` [S] No public network addresses in code · `05` [S] Remove dead code
+
+### G.PRM Performance — `G.PRM.01` toArray(T[]); Java11+ toArray(IntFunction) · `02` System.arraycopy/Arrays.copyOf · `04` No repeated regex pre-compile · `05` No unnecessary objects · `07` Close IO in try-with-resources · `08` No explicit GC · `09` No Finalizer · `10` No temp vars just for return
+
+### G.SEC Security — `G.SEC.01` [S] Security-check methods must be private/final · `02` [S] Custom ClassLoader getPermissions() must call super · `04` [S] Security manager for sensitive ops
+
+### G.SER Serialization — `G.SER.01` Avoid implementing Serializable · `02` Explicit serialVersionUID · `04` No serializing system resources · `05` [S] No serializing non-static inner classes · `07` [S] Prevent deserialization bypassing constructor security
+
+### G.TYP Types — `G.TYP.03` No float loop counters · `04` Use BigDecimal for exact calculations · `05` No == for float; no equals for wrappers · `06` Use isNaN() · `07` No hardcoded separators · `08` Locale.ROOT/ENGLISH for case/format · `09` Specify encoding for char↔byte · `11` Prefer primitives · `12` Explicit conversions · `13` instanceof before downcast
+
+### X.TST Testing — `X.TST.01` No shared test state · `02` Effective assertions on business logic · `03` No static mocks; prefer injectable deps · `04` Tag integration tests · `05` Test names match CUT; methodName_scenario_expected · `06` Given/When/Then structure
+
+### X.SQL Database — `X.SQL.01` No SQL concatenation; use PreparedStatement · `02` Paginate large queries · `03` WHERE fields indexed; leftmost prefix · `04` No SELECT * · `05` Batch bulk ops · `06` Minimize transaction scope · `07` Set transaction timeout
+
+### X.CON Concurrency — `X.CON.01` SimpleDateFormat not thread-safe; use DateTimeFormatter/ThreadLocal · `02` DCL must use volatile · `03` No locking String/Integer/Boolean · `04` computeIfAbsent not get+put · `05` No HashMap concurrent writes; ConcurrentHashMap · `06` ThreadPoolExecutor only; no Executors convenience
+
+### X.COL Collections — `X.COL.01` Arrays.asList() fixed-size; wrap for mutable · `02` subList() is view; copy for independent · `03` isEmpty() not size()==0 · `04` No LinkedList random access
+
+### X.PRM Performance — `X.PRM.01` No DB/RPC in loops · `02` StringBuilder in loops · `03` No multi-traverse Stream · `04` Pattern.compile not String.matches · `05` No large objects in hot paths
+
+### X.DEP Dependencies — `X.DEP.01` Versions in parent dependencyManagement · `02` No large libs for one method · `03` provided only for container deps · `04` No circular deps; extract shared module

--- a/.claude/rules/concurrency.md
+++ b/.claude/rules/concurrency.md
@@ -1,0 +1,92 @@
+---
+description: ThreadPoolExecutor, CompletableFuture, Reactor, EventBus, and lock conventions for agent-core-java.
+language: english
+paths:
+  - "src/main/java/com/openjiuwen/**/*.java"
+---
+
+# Concurrency Rules
+
+## Three Layers — Do Not Mix at API Boundary
+
+| Layer | Where | Return type | Bridge rule |
+|---|---|---|---|
+| `ThreadPoolExecutor` | Background workers, scheduled tasks | `void` / side-effects | — |
+| `CompletableFuture` | `TeamBackend`, team operations | `CompletableFuture<Boolean>` | `.join()` at sync boundaries only |
+| Reactor (`Mono`/`Flux`) | `BaseAgent`, `RunnerImpl`, streaming | `Mono<T>` / `Flux<T>` | `.subscribe()` |
+
+Do not introduce `Mono.fromFuture(...)` or `Future.fromMono(...)` bridges
+in new code. `TeamBackend` stays on `CompletableFuture`;
+`BaseAgent`/`RunnerImpl` stay on Reactor.
+
+## ThreadPoolExecutor
+
+```java
+new ThreadPoolExecutor(core, max, keepAlive, SECONDS,
+        new LinkedBlockingQueue<>(capacity),  // bounded, always
+        threadFactory,                         // named, daemon, with UncaughtExceptionHandler
+        new ThreadPoolExecutor.CallerRunsPolicy());
+```
+
+- **Bounded queue required** — unbounded hides backpressure.
+- **Named daemon threads** — `<subsystem>-<role>[-<id>]` prefix.
+  Non-daemon only if the pool must keep JVM alive (document why).
+- **Banned** (`X.CON.06`): `Executors.newCachedThreadPool()`,
+  `newFixedThreadPool()`, `newSingleThreadExecutor()`.
+- **Scheduled**: use `ScheduledThreadPoolExecutor` directly, not
+  `Executors.newScheduledThreadPool()`.
+
+## CompletableFuture
+
+- `thenApply` / `thenCompose` / `exceptionally` — standard chaining.
+- `supplyAsync` / `runAsync` — offload to worker (used in `BashTool`,
+  `CodeTool` for subprocess I/O).
+- **`.join()` allowed** at synchronous entry points (`dispatchTask`,
+  `destroyTeam`, `startup`, `approvePlan`).
+- **`.join()` forbidden** inside `CoordinationKernel.dispatch` and
+  event handlers — runs on single EventBus thread, blocking stalls
+  the coordination pipeline.
+
+## Reactor
+
+- Subscribe on `Schedulers.boundedElastic()` — never global parallel.
+- Use `ReactiveAdapters` for standard blocking→reactive conversions.
+- `Flux.usingWhen(...)` for AutoCloseable iterators (SSE streams).
+- `Flux.defer(...).doFinally(...)` for cleanup (see
+  `RunnerImpl.deferWithSessionCleanup`).
+
+## EventBus — Single-Threaded
+
+- One loop thread (`agent-teams-coordinator-<role>`, daemon). Wake
+  callback (`CoordinationKernel::dispatch`) runs on this thread.
+- All handlers execute serially on the loop thread. Async work
+  belongs in `TeamBackend.publishTeamEvent` → messager layer.
+- Shutdown via sentinel event, not `Thread.interrupt()`.
+- **Do not parallelize inside coordination handlers.**
+
+## Pinned Session ID
+
+Team event topics must use `TeamBackend.teamSessionId` (pinned at
+construction), never the thread-local `SpawnContext.getSessionId()`.
+This ensures leader and teammates agree on the same topic.
+
+## Lock Selection
+
+| Mechanism | When |
+|---|---|
+| `synchronized` (method) | Simple lifecycle guards |
+| `synchronized` (DCL) | Singleton init — requires `volatile` (`X.CON.02`) |
+| `ReentrantLock` | Fine-grained mutation guards |
+| `volatile` | Cross-thread flag visibility |
+| `AtomicBoolean`/`AtomicReference` | Lock-free flag/reference |
+| `ConcurrentHashMap` | Shared mutable maps — use `computeIfAbsent`, not `get`+`put` (`X.CON.04`) |
+
+No `StampedLock` or `ReadWriteLock` in this project.
+
+## Anti-patterns
+
+- `.join()` inside event handlers — blocks EventBus thread
+- `Mono.fromFuture(cf)` — crosses layer boundary
+- `HashMap` concurrent writes — use `ConcurrentHashMap` (`X.CON.05`)
+- Thread without name or `UncaughtExceptionHandler` — silent failure
+- `SpawnContext.getSessionId()` for team topics — breaks leader-teammate agreement

--- a/.claude/rules/dependency-management.md
+++ b/.claude/rules/dependency-management.md
@@ -1,0 +1,114 @@
+---
+description: Maven dependency, version, scope, banned-library, plugin, and CVE/upgrade rules for agent-core-java.
+language: english
+paths:
+  - "pom.xml"
+  - "src/main/java/**/*.java"
+  - "src/test/java/**/*.java"
+  - "examples/**/*.java"
+  - "documents/**/*.md"
+  - "Third_Party_Open_Source_Software_Notice.txt"
+---
+
+# Dependency Management Rules
+
+`pom.xml` is the canonical source of truth. Version inventory lives there
+in `<properties>` — read it directly rather than relying on this doc.
+
+## Core Rules
+
+1. **All versions as `${property}`** — never hard-code in `<dependency>` or
+   `<plugin>`. Naming: `<libname>.version` (library style, e.g.
+   `${jackson.version}`, `${bouncy-castle.version}`); plugins use
+   `${<plugin-name>.version}`.
+2. **One property per library family** — all Jackson artifacts share
+   `${jackson.version}`; all Testcontainers artifacts share
+   `${testcontainers.version}`. Never create per-artifact properties
+   (`${jackson-databind.version}`) for related artifacts.
+3. **No duplicate-purpose libraries** — check `pom.xml` before adding.
+   Current stack: Jackson (JSON), OkHttp (HTTP), SLF4J+Logback (logging),
+   SnakeYAML, Bouncy Castle, Milvus+pgvector (vector DB), PostgreSQL+SQLite
+   (RDBMS), Pulsar (MQ), PDFBox+POI (docs), OpenAI Java+DashScope (AI),
+   Reactor (reactive), JUnit+Mockito+AssertJ+Testcontainers+H2 (test).
+4. **Scope** — default: runtime framework deps; `provided`: annotation
+   processors (Lombok) or container-resolved annotations; `test`: test-only;
+   `optional`: opt-in extensions. Avoid `runtime` and `system`.
+5. **No `*-SNAPSHOT` deps on `main`.** Project's own SNAPSHOT version is OK
+   during dev cycles.
+6. **Plugin versions locked** — Maven 3.9+ requires it. Prefer
+   `<pluginManagement>` for inheritance.
+7. **License** — must be Apache 2.0 / MIT / BSD-2 / EPL-LGPL compatible.
+   Append to `Third_Party_Open_Source_Software_Notice.txt` when adding.
+
+## Banned Patterns
+
+| Banned | Use instead | Rule |
+|---|---|---|
+| `gson`, `org.json:json`, `jsonpath` | Jackson | Single JSON lib |
+| `org.apache.httpcomponents:*`, `java.net.HttpClient` | OkHttp | Single HTTP client |
+| `commons-io`, `commons-lang3` | JDK NIO / JDK 17 native | Avoid Apache Commons |
+| `guava` | JDK 17 (`List.of`, `Map.of`, `Optional`) | Avoid Guava |
+| JUnit 4 (`junit:junit`) | JUnit 5 (`org.junit.jupiter`) | Single test framework |
+| `hamcrest-core`, `jsonassert` | AssertJ | Single assertion lib |
+| `Executors.newCachedThreadPool/newFixedThreadPool` | `ThreadPoolExecutor` (bounded queue, named threads) | `X.CON.06` |
+| `log4j:*`, `java.util.logging` direct | SLF4J facade | `G.LOG.01` |
+| `SimpleDateFormat` | `DateTimeFormatter` | `X.CON.01` |
+
+## Lombok
+
+- `provided` scope; not on runtime classpath.
+- Do NOT add Lombok annotations (`@Data`, `@Builder`) to new files — prefer
+  explicit code, records, or hand-written builders. Existing annotations stay.
+- Must be in `maven-compiler-plugin` `<annotationProcessorPaths>` (already
+  configured).
+
+## OK / BAD (canonical)
+
+**OK** — version property + shared family version:
+```xml
+<properties>
+    <jackson.version>2.17.0</jackson.version>
+</properties>
+<dependencies>
+    <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson.version}</version>
+    </dependency>
+</dependencies>
+```
+
+**BAD** — hard-coded version, or per-artifact properties:
+```xml
+<!-- Hard-coded -->
+<version>2.17.0</version>
+
+<!-- Per-artifact properties for related artifacts -->
+<jackson-databind.version>2.17.0</jackson-databind.version>
+<jackson-datatype-jsr310.version>2.17.0</jackson-datatype-jsr310.version>
+```
+
+## Upgrade & CVE Check
+
+Run before merging dependency changes:
+```bash
+mvn versions:display-dependency-updates   # quarterly or pre-release
+mvn versions:display-plugin-updates
+mvn dependency:tree                         # catch transitive conflicts
+mvn dependency:analyze                      # unused declared deps (review before removing)
+```
+CVE: run `dependency-check-maven:check` or Snyk/trivy pre-release. Fix all
+HIGH/CRITICAL before merge.
+
+## Notes
+
+- BOM import in `<dependencyManagement>` is Maven-recommended for
+  multi-artifact libraries (Jackson, Testcontainers, Reactor). Current project
+  uses shared version properties — migration optional; new multi-artifact
+  libs should prefer BOM from the start.
+- `X.DEP.02`: avoid large libs for one method — inline or pick a small lib.

--- a/.claude/rules/error-codes-standard.md
+++ b/.claude/rules/error-codes-standard.md
@@ -1,0 +1,144 @@
+---
+description: StatusCode / BaseError / ErrorHelper usage conventions for agent-core-java. Enforces the unified error code system.
+language: english
+paths:
+  - "src/main/java/com/openjiuwen/**/*.java"
+---
+
+# Error Code Rules
+
+All exceptions raised inside the framework **must** go through the unified
+`com.openjiuwen.core.common.exception` system. This file lists enforceable
+hard rules. For design details, see the package-level Javadoc of
+`com.openjiuwen.core.common.exception`.
+
+## The Only Legal Way to Raise
+
+Every exception must carry a `StatusCode`. Business code **must not** raise
+bare `RuntimeException / IllegalStateException / IllegalArgumentException /
+NullPointerException`.
+
+```java
+// Preferred: ErrorHelper.raiseError / buildError
+import com.openjiuwen.core.common.exception.ErrorHelper;
+import com.openjiuwen.core.common.exception.StatusCode;
+
+ErrorHelper.raiseError(StatusCode.WORKFLOW_EXECUTION_ERROR, "reason=" + e.getMessage());
+ErrorHelper.raiseError(StatusCode.TOOL_EXECUTION_ERROR, msg, details, e, params);
+BaseError err = ErrorHelper.buildError(StatusCode.TOOL_EXECUTION_ERROR, "key", "value");
+
+// Direct throw is allowed only when the concrete class needs extra constructor args
+// (currently only ToolError.card / RunnerTermination.reason)
+throw new ToolError(StatusCode.TOOL_EXECUTION_ERROR, toolCard, "reason=" + e.getMessage());
+
+// Forbidden: bare RuntimeException, or BaseError without a StatusCode
+throw new RuntimeException("workflow broken");
+throw new IllegalStateException("bad state");
+```
+
+**Exceptions from external dependencies** must be caught at the module
+boundary and re-raised as a `BaseError` subclass with the original exception
+attached via `cause`. Do not let third-party exception types propagate up
+the call stack.
+
+```java
+// OK: wrap at boundary
+catch (IOException e) {
+    throw ErrorHelper.raiseError(StatusCode.SYS_OPERATION_ERROR, "reason=" + e.getMessage(), null, e, null);
+}
+
+// Bad: let IOException leak upward
+```
+
+## StatusCode vs Exception Class Are Orthogonal
+
+- **StatusCode** identifies the error (which module, which failure).
+- **Exception class** encodes control-flow semantics (retry / abort / terminate).
+
+| Exception Class | fatal | recoverable | Semantics |
+|---|---|---|---|
+| `FrameworkError` | true | false | Infrastructure broken; cannot continue |
+| `ValidationError` | false | false | Invalid input/config; no retry will help |
+| `ExecutionError` | false | true | Transient failure; retry may succeed |
+| `Termination` | false | false | Non-error control-flow stop |
+
+`StatusMapping` binds StatusCode to exception class.
+`ErrorHelper.raiseError` / `buildError` resolve the class automatically.
+**Do not guess the mapping** — get the naming right and the classification
+follows.
+
+## Adding a New StatusCode
+
+New entries go into `StatusCode.java` and must satisfy all of the following:
+
+1. **Code range** must fall in the numeric segment of the corresponding scope
+   (see the range table below). Cross-segment values break the range-based
+   fallback classification.
+
+   | Range | Scope |
+   |---|---|
+   | 100000-100999 | Workflow |
+   | 101000-119999 | Component |
+   | 120000-129999 | Agent |
+   | 130000-139999 | Runner |
+   | 140000-149999 | Graph |
+   | 150000-154999 | Context |
+   | 155000-157999 | Retrieval |
+   | 158000-159999 | Memory |
+   | 160000-179999 | Toolchain |
+   | 180000-180999 | Prompt |
+   | 181000-181999 | Model |
+   | 182000-182999 | Tool |
+   | 188000-188999 | Common |
+   | 190000-198999 | Session |
+   | 199000-199999 | SysOperation |
+
+2. **Name** follows `{SCOPE}_{SUBJECT}_{FAILURE_TYPE}`:
+   - `SCOPE` must be in `StatusCodeTemplate.ALLOWED_SCOPES`
+   - `FAILURE_TYPE` must be in `StatusCodeTemplate.ALLOWED_FAILURE_TYPES`
+     (`INVALID / NOT_FOUND / PARAM_ERROR / CONFIG_ERROR / INIT_FAILED /
+     CALL_FAILED / EXECUTION_ERROR / RUNTIME_ERROR / TIMEOUT / INTERRUPTED`, etc.)
+3. **Message template** uses `{name}` placeholders — never `%s` or `+`
+   concatenation. TIMEOUT templates must include `{timeout}`; generic errors
+   should carry `{reason}` or `{error_msg}`.
+4. **Code values must be unique.** Java `enum` does not silently alias
+   duplicates, but grep the numeric value before adding to avoid confusion.
+5. **Preserve the section comments.** The block-comment segmentation in
+   `StatusCode.java` is the file's only human index. Do not scramble it.
+
+No manual mapping registration is needed —
+`StatusMapping.resolveExceptionFactory()` resolves based on name keywords
+and code range at class-load time. If the default classification is wrong,
+prefer **fixing the name** so it matches a keyword rule. Only fall back to
+adding an entry in `StatusMapping.MANUAL_OVERRIDES` for genuine special
+cases.
+
+## Standalone Exceptions
+
+A few exceptions extend `RuntimeException` directly instead of `BaseError`.
+These are legacy or domain-specific exceptions that predate the unified
+system. **Do not add new standalone exceptions.** Instead, add a new
+`StatusCode` and use `ErrorHelper`.
+
+Existing standalone exceptions (do not replicate this pattern):
+- `GitHubError` — in `core.singleagent.skills`
+- `ToolInterruptException` — in `core.singleagent.interrupt`
+- `SandboxNotFoundException` / `SandboxOperationException` / `SandboxRecreateExhaustedException` — in `extensions.sys_operation.sandbox.providers.jiuwenbox`
+- `HumanAgentNotEnabledError` / `UnknownHumanAgentError` — in `agentteams.interaction`
+
+## Don'ts
+
+- **Don't branch on `e.getStatus().getCode()`** in business code. For
+  control-flow decisions use `instanceof ExecutionError` or read
+  `e.isRecoverable()` / `e.isFatal()`.
+- **Don't stuff runtime data into `StatusCode`.** The enum is an immutable
+  constant. Dynamic fields go through the `details` map or `params` varargs.
+- **Don't raise new exceptions on the error path.** `BaseError.renderMessage()`
+  is lazy-safe by design — missing keys render as `<missing:key>` rather than
+  throwing. Any extension to rendering must preserve this invariant.
+- **Don't swallow exceptions with `catch (BaseError e) { }`.** Either let it
+  propagate or convert it to an explicit StatusCode and re-raise.
+- **Don't use `ErrorHelper.systemError()` / `validateError()` / `terminate()`
+  when `raiseError()` would do.** The shorthand methods exist for
+  disambiguation when the keyword-based mapping resolves incorrectly; they
+  are not the default path.

--- a/.claude/rules/java-security.md
+++ b/.claude/rules/java-security.md
@@ -1,0 +1,94 @@
+---
+description: Credentials, sandbox operations, path validation, shell execution, and SSRF protection security rules.
+language: english
+paths:
+  - "src/main/java/com/openjiuwen/core/security/**"
+  - "src/main/java/com/openjiuwen/core/sysop/**"
+  - "src/main/java/com/openjiuwen/core/common/security/**"
+  - "src/main/java/com/openjiuwen/extensions/**"
+  - "src/main/java/com/openjiuwen/harness/security/**"
+  - "src/main/java/com/openjiuwen/harness/rails/security/**"
+alwaysApply: false
+---
+
+# Security Rules
+
+## Credential Handling
+
+- Never hard-code secrets, API keys, tokens, or real endpoints in source files.
+- All credentials must come from environment variables or config loaded at runtime.
+- Use `System.getenv("KEY")` with a safe default for tests.
+- In tests, use `System.getenv(..., "mock-api-key")` or mock the config — never real credentials.
+- API keys in example config files (`apiconfig.json`, `apiconfig_example.json`) must use placeholder values, not real keys.
+
+## .env Files
+
+- `.env` and `.env.*` files must not be committed.
+- These are already gitignored; do not override that.
+- `.env.example` files are allowed and should contain only placeholder values.
+
+## Sandbox Operations
+
+- `core/sysop/` handles shell and filesystem operations.
+- Sandboxed operations (`core/sysop/sandbox/`) enforce path scoping and guardrails.
+- Never bypass path validation or approval flows in sandbox code.
+- Preserve interrupt/confirm semantics for user-facing operations.
+- `SandboxGateway` is the singleton entry point; all sandbox access must go through it.
+
+## File Path Validation
+
+- Always validate user-supplied file paths before operations.
+- Use `PathChecker` in `com.openjiuwen.core.common.security` for sensitive-path checks.
+- Use `Path.normalize()` + `toAbsolutePath()` before comparing against allowed scopes.
+- Reject paths containing `..` that escape the allowed root.
+- `LocalFsOperation.isWithinRoot()` checks that resolved paths do not escape the sandbox root via `!root.relativize(candidate).startsWith("..")`.
+- On resolution failure, default to **deny** (fail-closed). `PathChecker.checkSensitive()` returns `true` (blocks access) when normalization throws.
+
+## Shell Execution
+
+- Never construct shell commands from unsanitized user input.
+- Use `ProcessBuilder` with list arguments — never `Runtime.exec()` with concatenated strings.
+- `LocalShellOperation` applies two security filters before every execution:
+  1. `checkAllowlist()` — first token of command must be in the configured allowlist.
+  2. `checkDangerousPatterns()` — regex pattern matching against configured dangerous patterns.
+- Do not bypass or weaken these filters without a security review.
+
+## SSRF Protection
+
+- `UrlUtils.checkUrlIsValid()` blocks internal IPs (loopback, site-local, link-local, any-local).
+- Can be disabled via `SSRF_PROTECT_ENABLED=false` env var — do not disable in production.
+- All HTTP client creation must go through `UrlUtils` validation when user-supplied URLs are involved.
+
+## SSL/TLS
+
+- Use `SslUtils.createStrictSslContext()` for production connections — enforces TLS 1.2+ with strong cipher suites.
+- Certificate paths must be within `SAFE_CERT_DIR`; file size capped at 1 MB.
+- `SslUtils.createInsecureSslContext()` (trusts all certs) is only for explicit `verify=false` scenarios — never use as default.
+
+## Third-Party Dependencies
+
+- Do not add dependencies without reviewing `pom.xml` and understanding the security implications.
+- New network-facing dependencies require review.
+- Check for known CVEs when upgrading dependencies (OWASP Dependency-Check or similar).
+
+## Security-Sensitive Areas
+
+- `core/common/security/` — path checking, SSRF protection, SSL, proxy, JSON safety
+- `core/sysop/` — shell, filesystem, sandbox operations
+- `harness/security/` — permission engine (ALLOW/ASK/DENY policy per tool)
+- `harness/rails/security/` — security rails (read-only mode enforcement)
+- `extensions/sys_operation/sandbox/` — isolation and provider code
+
+Changes to these areas require extra review and testing.
+
+## Guardrail and Permission Layers
+
+The project implements a layered security model. Understand the layer before making changes:
+
+| Layer | Package | Purpose |
+|---|---|---|
+| Guardrail | `core.security.guardrail` | User input risk detection (SAFE/LOW/MEDIUM/HIGH/CRITICAL) |
+| Permission | `harness.security` | ALLOW/ASK/DENY policy per tool via `PermissionEngine` |
+| Security Rail | `harness.rails.security` | Read-only mode enforcement, blocks write tools |
+| SysOp Validation | `core.sysop` | Shell allowlisting, dangerous pattern blocking, path traversal prevention |
+| Common Security | `core.common.security` | SSRF, SSL, path sensitivity, proxy credential handling |

--- a/.claude/rules/json-serialization.md
+++ b/.claude/rules/json-serialization.md
@@ -1,0 +1,118 @@
+---
+description: Jackson ObjectMapper, annotation, and serialization conventions for agent-core-java.
+language: chinese
+paths:
+  - "src/main/java/com/openjiuwen/**/*.java"
+  - "src/test/java/com/openjiuwen/**/*.java"
+---
+
+# JSON Serialization Rules
+
+Jackson 2.17 is the only JSON library. Do not introduce Gson, org.json,
+JsonB, or any other JSON library.
+
+## ObjectMapper
+
+### Reuse, never create per-call
+
+`ObjectMapper` is thread-safe after configuration. Creating one per method
+call wastes memory and CPU (serializer/deserializer cache rebuild).
+
+```java
+// OK — class-level singleton
+private static final ObjectMapper MAPPER = new ObjectMapper();
+
+// BAD — created per call
+public String toJson() {
+    return new ObjectMapper().writeValueAsString(this);  // forbidden
+}
+```
+
+The shared singleton is available via `JsonUtils.getMapper()`
+(`com.openjiuwen.core.common.security.JsonUtils`). Prefer it when
+default configuration suffices.
+
+### Configuration
+
+Most ObjectMapper instances in this project use **default configuration**
+(no custom features). When you need to customize:
+
+| Need | How |
+|---|---|
+| Ignore unknown properties | `.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)` |
+| Skip null fields in output | `@JsonInclude(Include.NON_NULL)` on the class (preferred over global config) |
+| Java 8 date/time | `jackson-datatype-jsr310` is on classpath; register via `.findAndRegisterModules()` or `.registerModule(new JavaTimeModule())` |
+
+Do not change global defaults (e.g., naming strategy, serialization features)
+on a shared ObjectMapper — create a dedicated instance with documented reason.
+
+## Annotations
+
+### Card classes
+
+Card classes (`BaseCard`, `AgentCard`, `ToolCard`, `WorkflowCard`,
+`SysOperationCard`, `GroupCard`) rely on Jackson's default bean
+serialization via getters/setters. Do not add `@JsonProperty` to
+fields that already follow camelCase naming.
+
+Use `@JsonProperty` only when the JSON key differs from the Java field
+name (e.g., `server_name` ↔ `serverName` in `McpToolCard`).
+
+### Common annotations by scenario
+
+| Annotation | When to use |
+|---|---|
+| `@JsonProperty("snake_key")` | JSON key differs from Java field name |
+| `@JsonInclude(Include.NON_NULL)` | Omit null fields from serialized output |
+| `@JsonIgnoreProperties(ignoreUnknown = true)` | Tolerate unknown fields in external API responses |
+| `@JsonCreator` + `@JsonProperty` | Immutable classes / enum with custom JSON representation |
+| `@JsonValue` | Enum that serializes as a single string/value |
+| `@JsonDeserialize(builder = ...)` | Builder-pattern deserialization |
+| `@JsonAnyGetter` / `@JsonAnySetter` | Catch-all map for extensible properties |
+| `@JsonIgnore` | Exclude a field from serialization entirely |
+
+Do not use `@JsonAutoDetect` — rely on public getters/setters or field
+visibility conventions.
+
+## Serialization Patterns
+
+### Card → JSON
+
+Cards are static metadata designed to cross process boundaries.
+They serialize via Jackson default bean introspection (getter/setter
+names → camelCase JSON keys). No manual `toMap()` / `toPayload()`
+methods on new Card classes — let Jackson handle it.
+
+### Error → JSON
+
+`BaseError.toMap()` constructs a `Map<String, Object>` with keys
+`code`, `status`, `message`, `params`, `raw_message`, `details`.
+`BaseError.toJson()` converts that map to JSON string.
+Do not add alternative serialization methods on error classes.
+
+### External API responses
+
+Use `@JsonIgnoreProperties(ignoreUnknown = true)` on DTO classes that
+map external API responses. This prevents deserialization failure when
+the API adds new fields.
+
+## Date/Time Serialization
+
+- `jackson-datatype-jsr310` is on the classpath.
+- For `OffsetDateTime` / `LocalDateTime` / `Instant`, register
+  `JavaTimeModule` on the ObjectMapper or use `findAndRegisterModules()`.
+- The project's `MessageSerializer` uses a custom format with
+  `__type__: "datetime"` markers for cross-process message payloads.
+  Do not replicate this pattern in new code — use `JavaTimeModule`
+  with ISO-8601 format instead.
+
+## Anti-patterns
+
+| Anti-pattern | Why | Fix |
+|---|---|---|
+| `new ObjectMapper()` inside a method | Per-call creation, no cache reuse | Class-level `static final` field |
+| Multiple ObjectMapper with identical config | Wasted memory | Share via `JsonUtils.getMapper()` |
+| `ObjectMapper` as instance field (non-static) | One per object instance | `private static final` |
+| Manual `toMap()` + `ObjectMapper` on new classes | Boilerplate, inconsistent | Jackson annotations |
+| `JsonNode` for simple POJO mapping | Over-engineering | Direct `readValue(json, MyClass.class)` |
+| `JSONObject` / `JSONArray` (org.json) | Wrong library | Jackson `ObjectNode` / `ArrayNode` |

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,89 @@
+---
+description: Logger selection, MDC trace-id, sanitization, and log level conventions for agent-core-java.
+language: english
+paths:
+  - "src/main/java/com/openjiuwen/**/*.java"
+  - "src/main/resources/logback.xml"
+---
+
+# Logging Rules
+
+## Logger Selection
+
+Use the `Loggers` facade (`com.openjiuwen.core.common.logging.Loggers`) —
+never instantiate SLF4J `LoggerFactory` or `java.util.logging.Logger`
+directly.
+
+| Logger field | Use for modules |
+|---|---|
+| `Loggers.AGENT` | `core.singleagent`, `agentteams.*`, `dev_tools.tune`, `agentevolving`, `core.application.llm` |
+| `Loggers.TOOL` | `harness.tools`, tool results in `AbilityManager` |
+| `Loggers.MULTI_AGENT` | `core.multiagent`, hierarchical teams |
+| `Loggers.CONTROLLER` | `core.controller`, `core.application` event handlers |
+| `Loggers.SESSION` | `core.session`, stream writers, checkpointers |
+| `Loggers.CONTEXT_ENGINE` | `core.context`, compressors, offloaders |
+| `Loggers.GRAPH` | `core.graph`, pregel, stream actors |
+| `Loggers.MEMORY` | `core.memory`, team memory, migrations |
+| `Loggers.SYS_OPERATION` | `core.sysop`, shell/fs/code operations |
+| `Loggers.LLM` | `core.foundation.llm`, model clients |
+| `Loggers.STORE` | `core.foundation.store` |
+| `Loggers.MCP` | `core.foundation.tool.mcp` |
+| `Loggers.RUNNER` | `core.security.guardrail` |
+| `Loggers.RETRIEVAL` | `core.retrieval.indexing` |
+
+New module with no match → use `Loggers.COMMON`; add a new field to
+`Loggers.java` if log volume is significant.
+
+## Declaration
+
+```java
+// Pattern A: inline static field
+private static final LoggerProtocol logger = Loggers.GRAPH;
+
+// Pattern B: direct call
+Loggers.AGENT.info("message: {}", value);
+```
+
+Always use `LoggerProtocol` type, never SLF4J `Logger`.
+
+## MDC and Trace ID
+
+MDC is managed **automatically** by `DefaultLogger` — do not call
+`MDC.put` / `MDC.remove` in business code.
+
+- Trace ID comes from `LoggingUtils.getSessionId()` (InheritableThreadLocal).
+- In team scenarios, set via `SpawnContext.setSessionId(sid)` /
+  `resetSessionId()` — never call `LoggingUtils.setSessionId()` directly.
+
+## Log Levels
+
+| Method | When |
+|---|---|
+| `debug` | Flow tracing; disabled in production |
+| `info` | Normal lifecycle events |
+| `warning` | Recoverable issues |
+| `error` | Failures affecting current operation |
+| `critical` | Failures requiring process restart |
+| `exception` | Log a throwable — preferred over `error(msg, e)` |
+
+## Sanitization (Automatic — Do Not Replicate)
+
+1. **Control chars** — `DefaultLogger.sanitize()` strips code < 32 or
+   == 127 from every message.
+2. **Sensitive fields** — `EventSanitizer` redacts 11 fields in
+   structured events: `messages`, `response_content`, `input_content`,
+   `query`, `arguments`, `result`, `message_content`, `tool_calls`,
+   `input_data`, `output_data`, `retrieved_memories`.
+
+Do not log raw user input, LLM responses, tool arguments, or tool
+results at `info`+ — these are only redacted in the structured event
+system. Use `debug` level or keep messages generic.
+
+## Anti-patterns
+
+- `LoggerFactory.getLogger(...)` — bypasses LazyLogger, MDC, sanitization
+- `System.out.println(...)` — no MDC, no level, no file routing
+- `MDC.put("trace_id", ...)` — managed by `DefaultLogger`
+- Logging full tool arguments at `info` — not redacted by `EventSanitizer`
+- `logger.error(msg)` without exception — loses stack trace; use
+  `logger.exception(msg, e)`

--- a/.claude/rules/templates-and-cases.md
+++ b/.claude/rules/templates-and-cases.md
@@ -1,0 +1,56 @@
+---
+description: Directs Claude to use templates, cases, and test-scenarios when creating code, fixing bugs, or writing tests.
+language: english
+paths:
+  - "src/main/java/**/*.java"
+  - "src/test/java/**/*.java"
+alwaysApply: false
+---
+
+# Templates, Cases & Test Scenarios
+
+## When creating new code
+
+Start from the matching template in `.claude/templates/`:
+
+| Target | Template |
+|---|---|
+| Card class (extends `BaseCard`) | `.claude/templates/card.java.tmpl` |
+| Service / business class | `.claude/templates/service.java.tmpl` |
+| Harness tool (returns `ToolOutput`) | `.claude/templates/tool.java.tmpl` |
+| Test class | `.claude/templates/test.java.tmpl` |
+
+Adding a new `StatusCode` entry → follow
+`.claude/templates/exception.md.tmpl`.
+
+`{{placeholders}}` in templates must be replaced with actual values.
+Do not copy blindly — read nearby code in the target package to align
+with local conventions.
+
+## When fixing bugs
+
+Search `.claude/cases/` for related cases first. Match by `module`
+field or `tags`. If the fix reveals a pattern worth recording, add a
+new case file.
+
+## When writing tests
+
+Check `.claude/test-scenarios/` for applicable scenarios that must be
+covered. Match by `module` or `type`. If a scenario has
+`Coverage: [ ]` (uncovered), add the corresponding test and flip it to
+`[x]`.
+
+When adding a new feature, create a `test-scenarios` entry for each P0
+path (null input, boundary, concurrency, exception propagation) even if
+the test is written immediately — this builds a regression net.
+
+## Case vs Test-Scenario
+
+| When to use Case | When to use Test-Scenario |
+|---|---|
+| An incident or tricky bug that already happened | An error path or boundary condition to cover |
+| Has root-cause analysis and a fix | Only needs input and expected behavior |
+| Post-hoc archive, looking back | Upfront design, preventing future |
+| Template has `severity` / `date` | Template has `priority` / `type` |
+
+Rule of thumb: **Something broke → log a Case; something might break → log a Test-Scenario.**

--- a/.claude/rules/test-flow.md
+++ b/.claude/rules/test-flow.md
@@ -1,0 +1,124 @@
+---
+description: Test location, style, mocking, coverage, and running conventions for agent-core-java.
+language: english
+paths:
+  - "src/test/java/**/*.java"
+alwaysApply: false
+---
+
+# Testing Rules
+
+## Test Location
+
+- Prefer targeted unit tests that mirror the source path.
+  Example: `src/main/java/com/openjiuwen/harness/DeepAgent.java` → `src/test/java/com/openjiuwen/harness/DeepAgentTest.java`
+- `src/test/java/`: all tests. Unit tests are the default.
+- `src/test/java/com/openjiuwen/core/systemtest/`: system/E2E tests — excluded from `mvn test` by surefire `<excludedGroups>`.
+
+## Choosing Test Patterns
+
+| Pattern | When to Use | Characteristics |
+|---|---|---|
+| **Unit test** | Isolated logic, no I/O, fast feedback | Mock all dependencies; `*Test.java` |
+| **Compatibility test** | Java-Python API parity contract | Enforces cross-language consistency; `*CompatibilityTest.java` |
+| **System/E2E test** | Full workflow, end-to-end correctness | Requires credentials/Docker; `*SystemTest.java`; `@Tag("system-test")` |
+
+**Decision rules**:
+- If it touches the filesystem, network, or external service → integration or system test
+- If it tests a single class in isolation → unit test
+- If the harness subsystem changes → ensure both unit and compatibility coverage
+- Coverage gate: 80% minimum for `com.openjiuwen.core` and `com.openjiuwen.harness`
+
+## Test Framework and Style
+
+- **JUnit 5** (Jupiter 5.10+) + **Mockito** (5.2+) + **AssertJ** (3.25+).
+- Test class naming: `*Test.java`, `*CompatibilityTest.java`, `*SystemTest.java`.
+- Test method naming: `methodName_scenario_expected` (e.g., `executeCmd_whenAllowlistMismatch_throwsValidationError`).
+- Use `@Nested` for grouping related test cases within a class.
+- Use `@TempDir` for file-based tests (the project uses this heavily — 80+ occurrences).
+- Use `@DisplayName` for complex test scenarios where the method name is not sufficient.
+- Structure tests as **Given / When / Then** (per `X.TST.06`).
+
+## Credentials and Mocks
+
+- Use mock defaults for credentials in tests. Never hard-code real API keys in test files.
+- For env-var-based config, use `System.getenv(...)` behind an injectable wrapper, then mock the wrapper in tests.
+- Mark tests that require real credentials with `@Disabled("requires real credentials")` and move them to system tests.
+
+## Mocking Conventions
+
+The project uses **programmatic Mockito** — no `@Mock`, `@InjectMocks`, or `@ExtendWith(MockitoExtension.class)`.
+
+```java
+// Preferred pattern: inline mock creation
+Model model = mock(Model.class);
+when(model.chat(any())).thenReturn(response);
+verify(model).chat(any());
+
+// For static methods (use sparingly)
+try (var mocked = mockStatic(AutoHarnessFactory.class)) {
+    mocked.when(() -> AutoHarnessFactory.createAssessAgent(any())).thenReturn(agent);
+    // ...
+}
+```
+
+**Rules**:
+- Do not introduce `@Mock` / `@InjectMocks` annotations — keep the existing inline style.
+- `mockStatic()` is allowed in auto-harness and integration tests; avoid in unit tests.
+- Prefer injecting dependencies via constructor over using `mockStatic()` or reflection.
+
+## Test Tags and CI
+
+| Tag | Annotation | Run by `mvn test`? | Purpose |
+|---|---|---|---|
+| (none) | — | Yes | Unit tests |
+| `system-test` | `@Tag("system-test")` | **No** (excluded) | E2E with real infra |
+| `agent-teams-*-slice` | `@Tag("agent-teams-config-slice")` etc. | Yes (not excluded) | Slice-specific compatibility tests |
+
+- Default surefire config: `<excludedGroups>system-test</excludedGroups>`.
+- To run system tests: `mvn test -Dsurefire.groups=system-test`.
+- To run a specific slice: `mvn test -Dsurefire.groups=agent-teams-config-slice`.
+- To run a single test class: `mvn test -Dtest=ClassName` or `-Dtest=ClassName#methodName`.
+
+## Reactive and Async Tests
+
+- For `Flux`/`Mono` testing, use `reactor-test` (`StepVerifier`).
+- For `CompletableFuture` testing, use `CompletableFuture.join()` with timeout or JUnit 5 `assertTimeout`.
+- Do not use `Thread.sleep()` in tests — use `awaitility` or `CompletableFuture.get(timeout)`.
+
+## Assertions
+
+- Use **AssertJ** for fluent assertions: `assertThat(actual).isEqualTo(expected)`.
+- Use descriptive messages for non-obvious conditions: `assertThat(result).as("should return empty list when no items found").isEmpty()`.
+- For exception assertions, prefer AssertJ's `assertThatThrownBy()`:
+  ```java
+  assertThatThrownBy(() -> errorHelper.raiseError(StatusCode.INVALID_PARAM))
+      .isInstanceOf(ValidationError.class)
+      .hasMessageContaining("invalid");
+  ```
+
+## Coverage
+
+- JaCoCo 0.8.11 is configured. Run: `mvn test jacoco:report`.
+- Report location: `target/site/jacoco/index.html`.
+- 80% line coverage minimum for `core` and `harness` modules.
+- No coverage threshold is enforced by the build yet — rely on review discipline.
+
+## Compatibility Tests
+
+`*CompatibilityTest.java` files enforce Java-Python API parity. Treat them as
+contract tests:
+- When a Python API changes, the corresponding Java compatibility test must be updated.
+- When adding a new Java public API, add a compatibility test if a Python equivalent exists.
+- Compatibility tests verify class existence, method signatures, and behavioral parity.
+
+## Running Tests
+
+| Command | What it does |
+|---|---|
+| `mvn test` | Run all unit + compatibility tests (excludes system-test) |
+| `mvn test -Dtest=ClassName` | Run a single test class |
+| `mvn test -Dtest=ClassName#methodName` | Run a single test method |
+| `mvn test -Dsurefire.groups=system-test` | Run system/E2E tests only |
+| `mvn test jacoco:report` | Run tests + generate coverage report |
+| `mvn compile -DskipTests` | Compile without running tests |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(mvn *)",
+      "Bash(mvnw *)",
+      "Bash(java *)",
+      "Bash(javac *)",
+      "Bash(git *)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./config/secrets.json)",
+      "Read(./**/secrets/**)",
+      "Read(./**/APIKEY/**)"
+    ]
+  },
+  "env": {},
+  "language": "chinese",
+  "includeGitInstructions": true
+}

--- a/.claude/skills/agent-team-guide/SKILL.md
+++ b/.claude/skills/agent-team-guide/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: agent-team-guide
+description: Agent Team quick build guide. Based on the leader-teammate team framework in the com.openjiuwen.agentteams package. Automatically applied when users build, assemble, or run an agent team, configure multi-agent collaboration, use LeaderTeammateAgentTeam, write team skill code, or call team tools such as spawn_member/create_task/send_message. Related keywords: agent team, multi-agent team, leader-teammate, LeaderTeammateAgentTeam, TeamAgent, team skill, spawn_member, team assembly, multi-agent collaboration, investment-analysis-team. Not applicable to: single-agent (ReAct/Workflow) issues, pure model configuration, discussions unrelated to the agentteams package.
+---
+
+# Agent Team Quick Build Guide
+
+This skill guides users to quickly build leader-teammate multi-agent collaboration teams based on the `com.openjiuwen.agentteams` package. The framework main line: `LeaderTeammateAgentTeam.Builder` declares the team -> `build()` creates `TeamAgent` via `TeamFactory` -> `interact / deliverInput / broadcast / dispatchTask` triggers collaboration.
+
+## Core Mental Model
+
+- `LeaderTeammateAgentTeam` is the declarative entry point, `TeamAgent` is the runtime host.
+- `TeamBackend` is the data and message hub, `Messager` is the transport layer, `TeamDatabase` is the storage layer.
+- `CoordinatorLoop` does not make decisions; it only handles wake-up and periodic polling. The actual collaboration logic is in `EventDispatcher` + team tools.
+- The leader collaborates with teammates through team tools (`send_message`/`update_task`/`claim_task`/`spawn_member`); teammates enter their own ReAct loop via `invokeForSpawn(...)`.
+
+## Key Concepts Quick Reference
+
+| Object | Purpose |
+| --- | --- |
+| `LeaderTeammateAgentTeam` | Top-level entry point and facade for the team, configured via `Builder` |
+| `TeamAgent` | Team coordinator and runtime host |
+| `TeamAgentSpec` | Team blueprint (name/members/modelPool/lifecycle/teammateMode/spawnMode/transport/storage) |
+| `TeamMemberSpec` | Member declaration (name/role/description/modelName) |
+| `TeamRole` | Four roles: `LEADER` / `MEMBER` / `HUMAN_AGENT` / `USER` |
+| `TeamBackend` | Maintains members, messages, tasks; bridges `Messager` and `TeamDatabase` |
+| `CoordinatorLoop` | Daemon thread, wake-up callbacks + mailbox/task periodic polling (default 30s) |
+| `EventDispatcher` | Consumes `InnerEventMessage` and transport events, converts them to collaboration actions |
+| `Messager` | Inter-process/in-process message bus (`InProcessMessager` / `PyZmqMessager`) |
+| `TeamMonitor` | Team monitor, subscribes to team/task/message/broadcast events |
+
+## Scenario Quick Reference Table
+
+Jump directly to the corresponding section based on the task scenario:
+
+| Scenario | Jump to Section |
+| --- | --- |
+| Assemble a minimal team from scratch | "Quick Start: Minimal Team" |
+| Assemble with predefined members | "Quick Start: With Predefined Members" |
+| Run the leader directly to process a task | "Run Mode: Run Leader Directly" |
+| Chat-type continuous interaction | "Run Mode: Continuous Interaction with User" |
+| Resume / switch session / destroy | "Run Mode: Resume and Destroy" |
+| Choose build_mode vs plan_mode | "Config Choice: teammateMode" |
+| Choose default / predefined / hybrid | "Config Choice: teamMode" |
+| Add human member (HITT) | "HITT: Human Member Collaboration" |
+| Add team skill | "Team Skill: Team Skill Discovery" |
+| Multi-stage task pipeline | "Multi-stage Data Flow" |
+| Check available team tools | "Team Tool Set" |
+| Troubleshoot member status | "Member State Machine" |
+
+## Quick Start: Minimal Team
+
+Minimal example: default leader is auto-included, no predefined teammates, `teamMode=default` (leader dynamically spawns at runtime).
+
+```java
+import com.openjiuwen.agentteams.LeaderTeammateAgentTeam;
+
+LeaderTeammateAgentTeam team = LeaderTeammateAgentTeam.builder()
+        .teamName("investment_analysis")
+        .description("Investment analysis collaboration team")
+        .lifecycle(LeaderTeammateAgentTeam.LIFECYCLE_TEMPORARY)
+        .teammateMode(LeaderTeammateAgentTeam.TEAMMATE_MODE_BUILD)
+        .spawnMode(LeaderTeammateAgentTeam.SPAWN_MODE_INPROCESS)
+        .storage(LeaderTeammateAgentTeam.STORAGE_SQLITE)
+        .leaderMemberName("team_leader")
+        .leaderDisplayName("Investment Lead")
+        .leaderPersona("Senior investment analysis expert, skilled at decomposing complex problems and assigning suitable members")
+        .language("cn")
+        .build()
+        .build(); // First build() assembles spec, second build() creates TeamAgent
+
+Map<String, Object> result = team.dispatchTask("Analyze the latest financial report of 600519");
+```
+
+**Two build() calls are both required**: The first generates `TeamAgentSpec`, the second actually creates `TeamAgent` via `TeamFactory.createAgentTeam(...)`.
+
+## Quick Start: With Predefined Members
+
+Add `addPredefinedMember(...)` to declare fixed members. As long as a non-`HUMAN_AGENT` predefined member is passed, the `Builder` automatically resolves `teamMode` to `hybrid`.
+
+```java
+import com.openjiuwen.agentteams.schema.team.TeamMemberSpec;
+import com.openjiuwen.agentteams.schema.team.TeamRole;
+
+LeaderTeammateAgentTeam team = LeaderTeammateAgentTeam.builder()
+        .teamName("investment_analysis")
+        .lifecycle(LeaderTeammateAgentTeam.LIFECYCLE_TEMPORARY)
+        .addPredefinedMember(TeamMemberSpec.builder()
+                .name("fundamental_analyst")
+                .role(TeamRole.MEMBER)
+                .description("Fundamental analyst")
+                .modelName("fundamental_model")
+                .build())
+        .addPredefinedMember(TeamMemberSpec.builder()
+                .name("technical_analyst")
+                .role(TeamRole.MEMBER)
+                .description("Technical analyst")
+                .modelName("technical_model")
+                .build())
+        .build()
+        .build();
+```
+
+## Prerequisites (Must Read for Beginners)
+
+Before copying the quick start code above, confirm three things, otherwise it won't run:
+
+1. **Maven compile path**: The `examples/` directory is not in the Maven compile path by default (`pom.xml` doesn't register it as a source root). Either move `examples/` under `src/main/java/`, or add it as a source root in your IDE, otherwise `examples.agent_teams.AgentTeamE2eExample` won't be found.
+2. **API configuration**: Fill real values for `API_BASE` / `API_KEY` / `MODEL_PROVIDER` / `MODEL_NAME` in `src/main/resources/apiconfig.json`. `SharedExampleApiConfigLoader` reads this file from classpath by default. Placeholder values (like `your-api-key`) will throw `IllegalStateException: Missing required key in apiconfig.json` at startup. Override with `-Dopenjiuwen.example.config=<path>` or `OPENJIUWEN_API_CONFIG` environment variable.
+3. **Team skill placement**: If using team skills (like `investment-analysis-team`), place them in a directory the framework will scan, otherwise the leader won't discover them:
+   - Team workspace `skills/`: `~/.openjiuwen/.agent_teams/<team_name>/team-workspace/skills/`
+   - Global: `~/.openjiuwen/workspace/skills/`
+   - `skills/` subdirectory of the current working directory
+
+Startup command (example):
+
+```bash
+mvn exec:java -Dexec.mainClass=examples.agent_teams.AgentTeamE2eExample
+```
+
+## Configuration Parameters Quick Reference
+
+| Field | Values | Default | Description |
+| --- | --- | --- | --- |
+| `lifecycle` | `temporary` / `persistent` | `temporary` | Temporary team is destroyed after task completion; persistent team keeps running |
+| `teammateMode` | `build_mode` / `plan_mode` | `build_mode` | See "teammateMode" below |
+| `spawnMode` | `inprocess` / `process` | `inprocess` | In-process shares JVM; process requires pyzmq config |
+| `transport` | `inprocess` / `pyzmq` | Derived from spawnMode | inprocess defaults to inprocess |
+| `storage` | `sqlite` / `memory` / `postgresql` / `mysql` | `sqlite` | Team persistence backend |
+| `teamMode` | `default` / `predefined` / `hybrid` | Derived from predefined members | See "teamMode" below |
+| `modelPoolStrategy` | `round_robin` / `by_model_name` | `round_robin` | Model allocation strategy |
+
+### Config Choice: teammateMode
+
+Determines the execution path after a teammate claims a task:
+
+- `build_mode`: Teammate executes autonomously and marks completion directly, no leader approval needed. **Default choice**.
+- `plan_mode`: Teammate must first `write_plan` to submit a plan, wait for leader `approve_plan` approval before executing. Use when strict quality gate control is needed.
+
+### Config Choice: teamMode
+
+Determines the leader's workflow template and available team tools:
+
+- `default`: Leader dynamically spawns teammates at runtime, tool set includes `spawn_member`. **Default for minimal team**.
+- `predefined`: All members are determined at assembly time, `spawn_member` is excluded.
+- `hybrid`: Has both predefined members and allows leader to dynamically expand. **Automatically becomes hybrid when predefined members are passed**.
+
+### Configuration Details
+
+- When no explicit leader is declared, `TeamAgentSpec.ensureLeader()` automatically adds a default leader named `team_leader`.
+- When `spawnMode=inprocess`, members share the same JVM, convenient for local debugging; in `process` mode, members run as independent processes and must configure `pyzmq` transport.
+- Reserved member names (`team_leader` / `human_agent` / `user`) cannot be arbitrarily used; `TeamAgentSpec.validate()` checks this.
+- File layout is managed by `TeamPaths`: team directory `~/.openjiuwen/.agent_teams/<team_name>/`, shared memory under `team-workspace/team-memory/`.
+
+## Run Mode: Run Leader Directly
+
+After assembly, call `dispatchTask(...)` directly:
+
+```java
+Map<String, Object> result = team.dispatchTask("Summarize this week's investment views");
+// result contains team_id, session_id, status, leader, route, target, delivered_content, message_id
+```
+
+When streaming output is needed:
+
+```java
+Iterator<Object> chunks = team.agent().stream(Map.of("query", query), sessionApi);
+while (chunks.hasNext()) {
+    Object chunk = chunks.next();
+    // Process streaming fragment
+}
+```
+
+## Run Mode: Continuous Interaction with User
+
+Both `interact(...)` / `deliverInput(...)` put input into `CoordinatorLoop`, the difference is whether the agent runtime goes through steer:
+
+```java
+team.interact("Look at the valuation from another angle");      // Equivalent to deliverInput(message, true)
+team.deliverInput("Supplement with the latest data", false);
+
+// Leader proactive broadcast
+String messageId = team.broadcast("Please check your responsible task status");
+```
+
+## Run Mode: Resume and Destroy
+
+```java
+// Persistent team: resume from existing snapshot
+TeamAgent restored = TeamFactory.recoverAgentTeam(snapshot);
+
+// Switch to new session: keep alive teammates, re-spawn
+team.resumeForNewSession(newSessionId);
+
+// Resume existing session: no re-spawn, just session binding
+team.recoverForExistingSession(existingSessionId);
+
+// Batch recover abnormal members
+List<String> restarted = team.recoverTeam();
+
+// Destroy
+team.destroyTeam();          // Equivalent to destroyTeam(true)
+team.destroyTeam(false);     // Don't force-close other members
+```
+
+Get snapshot via `team.snapshot()`, which internally contains spec, context, leader_inbox, messages, and model allocator state.
+
+## Team Tool Set
+
+`TeamTools.createTeamTools(role, backend, teammateMode, excludeTools, ...)` filters tools by role, `TeamAgent.registerTeamTools()` adds `team_name.member_name` suffix to each tool's card id to avoid conflicts.
+
+| Category | Tool | Description |
+| --- | --- | --- |
+| Leader Exclusive | `build_team` / `clean_team` / `spawn_member` / `shutdown_member` / `approve_plan` / `approve_tool` / `create_task` / `update_task` / `list_members` | Only the leader can call these |
+| Member Exclusive | `claim_task` / `enter_worktree` / `exit_worktree` | Only teammates can call these |
+| Shared | `view_task` / `send_message` / `workspace_meta` | Both leader and teammate have these |
+| Human agent | `send_message` (only this one) | Members with `role=human_agent` only have this tool |
+
+**Dynamic Adjustment Rules**:
+
+- `teamMode=predefined` -> `spawn_member` is excluded, leader cannot expand members.
+- `teammateMode=plan_mode` -> teammate gets extra `write_plan`, leader gets extra `approve_plan`.
+- All members (including leader) additionally register `file_io` for reading/writing files in the team workspace (typically writing `.team/reports/T*.md`).
+
+## Member State Machine
+
+Members transition between two sets of states at runtime:
+
+- **MemberStatus**: `UNSTARTED -> READY -> BUSY -> SHUTDOWN_REQUESTED -> SHUTDOWN`, error path goes through `RESTARTING` / `ERROR`. Each transition publishes a `member_status_changed` event via `Messager`.
+- **ExecutionStatus**: `IDLE -> STARTING -> RUNNING -> COMPLETING -> COMPLETED`, cancel and failure branches: `CANCEL_REQUESTED` / `CANCELLING` / `CANCELLED` / `FAILED` / `TIMED_OUT`.
+
+Both enums have built-in `canTransitionTo(...)` legality checks. When troubleshooting member anomalies, first check `MemberStatus` for `ERROR` / `RESTARTING`, then check `ExecutionStatus` for `FAILED` / `TIMED_OUT`.
+
+## Event-Driven and Coordination Mechanism
+
+`TeamAgent` collaboration relies on two event streams merging into the `CoordinatorLoop` queue, then unified dispatch by `EventDispatcher.dispatch(event)`.
+
+**Event Sources**:
+
+| Source | Type | Trigger |
+| --- | --- | --- |
+| JVM Internal | `InnerEventMessage` (`USER_INPUT` / `POLL_MAILBOX` / `POLL_TASK` / `SHUTDOWN`) | `CoordinatorLoop` periodic polling, `interact/deliverInput` enqueuing, `stop()` sends SHUTDOWN |
+| Transport Layer | `EventMessage`, published to 4 topics: `team:<name>` / `team:task` / `team:message` / `team:broadcast` | Team tool calls, `TeamMemberState` transitions, `TeamTaskManager` state changes |
+
+`CoordinationManager.subscribeTransport()` subscribes to the 4 topics when the leader first `stream(...)` or teammate `invokeForSpawn(...)`. All transport events go through **echo suppression** before enqueuing (`localMember.equals(event.getSenderId())` skips), preventing members from receiving their own events.
+
+**Key Event Routing**:
+
+| Event | Handling |
+| --- | --- |
+| `USER_INPUT` | Parse `@mention` routing or `deliverInput(text)`; `@member_name xxx` goes directly through `UserInbox.direct(...)`, doesn't enter leader ReAct |
+| `POLL_MAILBOX` | 30s period, delivers unread messages to members one by one |
+| `POLL_TASK` | `checkStaleClaimedTasks` (60s without completion) + `checkStalePendingTasks` (10min unassigned) |
+| `team_cleaned` | Non-leader calls `shutdownSelf()` |
+| `member_results_delivery` | Only when `target_assignee == localMember` then `deliverInput(content)`, supporting multi-stage pipeline |
+
+**Auto-completion**: `StreamController` calls `tryAutoCompleteMemberTasks` at the end of a member's ReAct round -- if the member sent `send_message` to the leader this round, the framework automatically claims + completes all unfinished tasks under that member. The member doesn't need to explicitly call `complete_task`.
+
+## Multi-stage Data Flow
+
+Multi-stage pipelines like `investment-analysis-team` rely on framework built-in mechanisms, no need for leader explicit scheduling:
+
+1. **Create tasks with dependencies**: Leader `create_task(..., dependencies=["T1","T2"])`, `TeamTaskManager.add(...)` sets the dependent task as `blocked` initially, records edges in `TaskDependencyRecord` table.
+2. **Member completes upstream task**: After member claims and completes T1, `completeResult(...)` marks it as `completed`, publishes `task_completed`.
+3. **Framework captures upstream output**: `EventDispatcher.tryAutoCompleteMemberTasks` detects member sent `send_message` to leader, collects message content into `TeamResultCollector` (key = `teamName + memberName`).
+4. **Auto-unblock downstream**: `tryDeliverToNextStage` iterates all `blocked` tasks, when all `dependencies` are `completed`, retrieves each dependency assignee's output from `TeamResultCollector`, assembles a `member_results_delivery` event, publishes it to the downstream assignee via `team:message` topic.
+5. **Downstream member receives**: `EventDispatcher` verifies `target_assignee == localMember` then `deliverInput(content)`, injecting upstream results into its ReAct loop.
+6. **`team_mode=predefined` special handling**: When downstream assignee includes `leader`, the delivered message is accompanied by a strong constraint prompt "You are the leader, must use file_io to write the final report and complete this task yourself", preventing the leader from re-delegating the final task.
+
+## HITT: Human Member Collaboration
+
+When `enableHitt=true`, members with `role=HUMAN_AGENT` can be added:
+
+- `TeamRail.buildTeamHittSection(...)` generates different collaboration rules for leader, teammate, and human_agent perspectives.
+- Leader cannot ask human members in plain text, must use `send_message`.
+- Human agent only has the `send_message` tool, no `claim_task` / `update_task` / `spawn_member`.
+- `exposeHumanAgentsToTeammates` controls whether human members are visible to teammates.
+- If `HUMAN_AGENT` members exist, `enableHitt` must also be enabled, otherwise `TeamAgentSpec.validate()` throws an error.
+
+## Team Skill: Team Skill Discovery
+
+`TeamAgent.setupAgent()` defaults to `enableSkillDiscovery(true)` + `skillMode("all")`, scanning directories:
+
+- Team workspace `skills/` node
+- Current working directory (`System.getProperty("user.dir")`)
+- `~/.openjiuwen/workspace/skills`
+
+`HarnessFactory` automatically appends `SkillUseRail` when `hasConfiguredSkills(source) || source.isEnableSkillDiscovery()`, responsible for:
+
+- Scanning skill directories, loading local and remote skills (incremental hot-reload based on mtime signatures).
+- Registering `list_skill` and `skill_tool` tools, enabling leader/teammate to discover and invoke skills in the ReAct loop.
+- Injecting a prompt section named `skills` in `beforeModelCall`.
+
+**Two evolutionary rails** (`com.openjiuwen.harness.rails`):
+
+- `TeamSkillRail`: Listens to member `view_task`, triggers a "team evolution analysis" event when all tasks are complete, consolidating collaboration experience.
+- `TeamSkillCreateRail`: After leader calls `spawn_member` reaching threshold (default 2 times), schedules a follow-up prompt guiding the leader to use the `team-skill-creator` skill to codify this collaboration pattern as a new team skill.
+
+Place team skills under the team workspace `skills/` or `~/.openjiuwen/workspace/skills/`, the team will automatically discover and load them on the next execution.
+
+## Team Skill Standard Directory Structure
+
+A complete team skill (like `investment-analysis-team`) consists of 5 parts:
+
+| File | Responsibility | When Read |
+| --- | --- | --- |
+| `SKILL.md` | Team metadata: name/version/kind: team-skill/role overview | Read after leader discovers this skill in ReAct loop |
+| `roles/*.md` | Each role's identity, success criteria, Output Schema, `## Inline Persona for Teammate` section | Read before leader `spawn_member`, extract inline persona section and paste into dispatch prompt (**framework doesn't auto-load**, leader must explicitly read) |
+| `workflow.md` | Complete execution script (mermaid + Step 0~7 protocol) | Read before first dispatch, is the leader's complete playbook |
+| `bind.md` | Resource constraints, behavioral constraints, failure handling | Read when triggering resource constraints / failure handling / degradation; `TeamRail` injects Resource Constraints into leader prompt |
+| `dependencies.yaml` | External skill / tools dependency declaration | Read at **startup** by leader's pre-flight (workflow Step 0), determines go/no-go |
+
+## Typical Runtime Lifecycle
+
+1. Use `LeaderTeammateAgentTeam.builder()` to configure teamName, lifecycle, teammateMode, spawnMode, transport, storage, leader, predefined members.
+2. Call `build()` -> `TeamFactory.createAgentTeam(spec)` constructs `TeamAgent`, internally assembling `ModelAllocator`, `TeamBackend`, `CoordinatorLoop`, `EventDispatcher`, `RecoveryManager`, `SpawnManager`, `StreamController`, and creates the leader's own `DeepAgent`.
+3. Call `interact(...)` / `deliverInput(...)` / `dispatchTask(...)` / `stream(...)` to trigger `CoordinatorLoop` wake-up, `EventDispatcher` consumes events.
+4. Leader collaborates with teammates through team tools; teammates enter their own ReAct loop via `invokeForSpawn(...)`.
+5. After tasks complete, `temporary` team is wrapped up by leader calling `shutdown_member` then `clean_team`; `persistent` team keeps running waiting for new instructions.
+
+## Usage
+
+1. **Scenario positioning**: First use the "Scenario Quick Reference Table" to jump to the corresponding section based on current task.
+2. **Copy Template**: Code blocks in the quick start sections can be directly copied and modified. Remember to change `teamName`, `leaderPersona`, member names, `modelName`.
+3. **Config Decision**: When unsure about configuration, check "Configuration Parameters Quick Reference" and "Config Choice" sections.
+4. **Troubleshoot**: First check "Pitfall FAQ", then "Member State Machine" and "Multi-stage Data Flow".
+5. **Extend Capabilities**: Need team skill see "Team Skill" section; need human collaboration see "HITT" section.
+6. **Don't Fabricate When Unsure**: API details are subject to source code; this skill does not replace official API documentation.
+
+## Pitfall FAQ (High-frequency Issues Quick Reference)
+
+Most common pitfalls for beginners, located by symptom:
+
+| Symptom | Cause | Solution |
+| --- | --- | --- |
+| `IllegalStateException: Missing required key in apiconfig.json` | API configuration has placeholder values | Fill real `API_KEY` / `API_BASE` / `MODEL_NAME`, see "Prerequisites" |
+| Can't find `examples.agent_teams.AgentTeamE2eExample` class | `examples/` is not in Maven compile path | Move `examples/` under `src/main/java/`, or add source root in IDE |
+| Error calling `dispatchTask` after `team.builder()` | Only called one `build()` | `LeaderTeammateAgentTeam.builder().build().build()`, both build calls are required: first generates spec, second creates TeamAgent |
+| Member has nothing to do after leader spawns it | Only `spawn_member` without `create_task` | After spawn, use `create_task` to create a task, member can then `claim_task` |
+| `spawn_member` fails under `teamMode=predefined` | Tool is excluded | predefined mode doesn't allow member expansion; use `hybrid` or `default` to expand |
+| Member task status stuck at `claimed` after completion, doesn't transition to `completed` | Member didn't send `send_message` to leader | `tryAutoCompleteMemberTasks` requires member to have sent `send_message` to leader for auto-complete; or have member explicitly call `complete_task` |
+| `@member_name` message enters leader's ReAct instead of going directly to member | Mention routing has wrong member name | Check member name spelling; `@member_name xxx` should go directly through `UserInbox.direct(...)`, entering leader ReAct means no match |
+| `process` spawn mode startup error | No pyzmq transport configured | `spawnMode=process` requires `transport=pyzmq`; use `inprocess` for local debugging |
+| Leader doesn't know team skills are available | Skill placed in wrong directory | Place under team workspace `skills/` or `~/.openjiuwen/workspace/skills/`, see "Prerequisites" |
+| Member has no persona / role definition lost | `roles/*.md` inline persona section not read by leader | Framework doesn't auto-load `roles/*.md`, leader must `read_file` then extract `## Inline Persona for Teammate` section and paste into dispatch prompt |
+| `TeamAgentSpec.validate()` error: HUMAN_AGENT member without HITT enabled | Has `role=HUMAN_AGENT` member but `enableHitt` not enabled | `enableHitt(true)`, or remove HUMAN_AGENT member |
+| Task dependencies don't unlock, downstream member never receives `member_results_delivery` | Upstream task not truly completed, or upstream member didn't send `send_message` | Check `TaskRecord.status` is truly `completed`; check `TeamResultCollector` has upstream output (key = `teamName + memberName`) |
+| `temporary` team doesn't auto-destroy after task completion | Leader didn't call `clean_team` | Temporary team needs leader to call `shutdown_member` then `clean_team` to wrap up; `CoordinatorLoop` prompts leader when `nudgeIdleAgent` determines all complete |
+
+## Subsystem and Sub-package Quick Reference
+
+| Sub-package | Key Classes | Responsibility |
+| --- | --- | --- |
+| `agentteams` | `LeaderTeammateAgentTeam`, `TeamFactory`, `TeamConstants`, `I18n`, `TeamPaths` | Top-level entry, factory, reserved names, i18n, path layout |
+| `agentteams.agent` | `TeamAgent`, `CoordinatorLoop`, `EventDispatcher`, `TeamRail`, `TeamMemberState`, `AgentConfigurator`, `ModelAllocator` | Coordinator, wake loop, event dispatch, prompt rail, model allocation |
+| `agentteams.messager` | `Messager`, `InProcessMessager`, `PyZmqMessager` | Transport layer abstraction and implementations |
+| `agentteams.spawn` | `SpawnHandle`, `InProcessSpawnHandle`, `ProcessSpawnHandle` | Spawn handle and session context |
+| `agentteams.worktree` | `WorktreeManager`, `WorktreeRail`, `WorktreeSession` | Git worktree isolation and lifecycle |
+| `agentteams.teamworkspace` | `TeamWorkspaceManager`, `WorkspaceFileLock` | Team shared workspace, file locks |
+| `agentteams.monitor` | `TeamMonitor`, `MonitorEvent`, `TeamInfo`, `MemberInfo`, `TaskInfo` | Team event monitoring and state snapshots |
+| `agentteams.interaction` | `Router`, `MentionRoute`, `UserInbox`, `HumanAgentInbox` | Mention routing, inboxes |
+| `agentteams.tools` | `TeamBackend`, `TeamTools`, `TeamTaskManager`, `TeamResultCollector` | Team tool implementations |
+| `agentteams.tools.database` | `TeamDatabase`, `DatabaseConfig`, `TaskDependencyRecord` | Persistence abstraction and multi-backend adaptation |
+| `agentteams.schema.blueprint` | `TeamAgentSpec` | Team blueprint |
+| `agentteams.schema.team` | `TeamMemberSpec`, `TeamRole`, `TeamRuntimeContext`, `ModelPoolEntry` | Team/member/context/model pool schema |
+| `agentteams.schema.status` | `MemberStatus`, `ExecutionStatus` | Member and execution status enums |
+
+## Not Yet Implemented / Usage Boundaries
+
+- Complete controller-style declarative team orchestration (leader runtime spawn is still the primary path).
+- Unified selector API for multiple `ModelAllocator` strategies (currently only built-in `round_robin` and `by_model_name`).
+- Complete lifecycle for health check and auto-recovery (`SpawnHandle` exposes `startHealthCheck`, but it's not enabled by default).
+
+**Safe approach**: Build team assembly on `LeaderTeammateAgentTeam + TeamAgent + TeamBackend`; extend `agent` / `tools` / `monitor` sub-packages when finer collaboration control is needed.
+
+## Reference Entry Points
+
+- Full documentation: `documents/zh/2.Development Guide/Multi-Agent/AgentTeams.md`
+- Example code: `examples/agent_teams/AgentTeamE2eExample.java` + `AgentTeamE2eExampleSupport.java`
+- Example team skill: `examples/agent_teams/skills/investment-analysis-team/`
+- API documentation: `documents/zh/API Documentation/com.openjiuwen.agentteams/` sub-modules
+- **Minimal runnable example**: `references/MinimalRunnableExample.java` (self-contained, includes model config, copy and run)

--- a/.claude/skills/agent-team-guide/references/MinimalRunnableExample.java
+++ b/.claude/skills/agent-team-guide/references/MinimalRunnableExample.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package references;
+
+import com.openjiuwen.agentteams.LeaderTeammateAgentTeam;
+import com.openjiuwen.core.runner.Runner;
+
+import java.util.Map;
+
+/**
+ * Minimal runnable agent team assembly example.
+ *
+ * Prerequisites (all required, otherwise it won't run):
+ *   1. Move this file or the entire examples/ directory under src/main/java/, so it enters the Maven compile path.
+ *   2. Fill real values in src/main/resources/apiconfig.json (API_BASE / API_KEY / MODEL_PROVIDER / MODEL_NAME).
+ *      Override with -Dopenjiuwen.example.config=<path> or OPENJIUWEN_API_CONFIG environment variable.
+ *
+ * Startup command:
+ *   mvn exec:java -Dexec.mainClass=references.MinimalRunnableExample
+ *
+ * Or run the main method directly in IDE.
+ *
+ * This example aligns with examples/agent_teams/AgentTeamE2eExample.java, but removes the interaction loop,
+ * streaming rendering, color control and other distracting logic, only keeping the "assemble -> trigger -> wrap-up"
+ * main line for easy understanding by beginners.
+ */
+public final class MinimalRunnableExample {
+
+    private MinimalRunnableExample() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        // 1. Assemble the team: both build() calls are required
+        //    The first build() assembles TeamAgentSpec
+        //    The second build() actually creates TeamAgent via TeamFactory
+        LeaderTeammateAgentTeam team = LeaderTeammateAgentTeam.builder()
+                .teamName("minimal_demo")
+                .description("Minimal runnable team example")
+                .lifecycle(LeaderTeammateAgentTeam.LIFECYCLE_TEMPORARY)
+                .teammateMode(LeaderTeammateAgentTeam.TEAMMATE_MODE_BUILD)
+                .spawnMode(LeaderTeammateAgentTeam.SPAWN_MODE_INPROCESS)
+                .storage(LeaderTeammateAgentTeam.STORAGE_SQLITE)
+                .leaderMemberName("team_leader")
+                .leaderDisplayName("Team Lead")
+                .leaderPersona("Experienced task coordinator, skilled at decomposing problems and assigning suitable members")
+                .language("cn")
+                // Model configuration: in real projects, typically use SharedExampleApiConfigLoader to read apiconfig.json
+                // Here for self-contained example, pass directly; replace with your config loading method in real usage
+                .configureModelClient(
+                        "your-provider",           // MODEL_PROVIDER, e.g. openai / azure / qwen
+                        "your-api-key",             // API_KEY
+                        "https://your-api-base",    // API_BASE
+                        "your-model-name",          // MODEL_NAME
+                        false                       // SSL_VERIFY
+                )
+                .build()
+                .build();
+
+        // 2. Start Runner (framework internal threads, resource management)
+        Runner.start();
+
+        try {
+            // 3. Trigger a task dispatch
+            //    dispatchTask is a synchronous call, returns team execution result
+            //    For temporary teams, leader will call shutdown_member + clean_team to wrap up after task completion
+            String query = args.length > 0 ? args[0] : "Spawn 2 people to report numbers, divide into 2 dependent tasks";
+            System.out.println(">>> Dispatching task: " + query);
+
+            Map<String, Object> result = team.dispatchTask(query);
+
+            // 4. Output result
+            //    result contains team_id / session_id / status / leader / route / target / delivered_content / message_id
+            System.out.println(">>> Execution result:");
+            result.forEach((k, v) -> System.out.println("    " + k + " = " + v));
+        } finally {
+            // 5. Wrap up: close team + stop Runner
+            //    For temporary teams, leader has usually already clean_team'd; close mainly releases local resources
+            team.agent().close();
+            Runner.stop();
+            System.out.println(">>> Done.");
+        }
+    }
+}

--- a/.claude/skills/caveman-install/SKILL.md
+++ b/.claude/skills/caveman-install/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: caveman-install
+description: >
+  Install and configure the caveman plugin for Claude Code on the current machine.
+  Trigger when user says "install caveman", "setup caveman", "配置 caveman", "安装 caveman",
+  or when caveman hooks/statusline are missing from settings.json.
+  Also applies when user wants to verify, troubleshoot, or uninstall caveman.
+  Not applicable to: using caveman mode (that's the built-in caveman skill),
+  general Claude Code configuration unrelated to caveman.
+---
+
+# Caveman Plugin Installation Guide
+
+Caveman is a Claude Code plugin that reduces output tokens ~65% by enforcing
+terse, article-free communication. This skill covers install, verify,
+configure, and uninstall on Windows.
+
+## Quick Install
+
+### Windows (PowerShell 5.1+)
+
+```powershell
+irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
+```
+
+If execution policy blocks it:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+irm https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.ps1 | iex
+```
+
+### WSL / Git Bash
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash
+```
+
+### Claude Code Only (Manual)
+
+```bash
+claude plugin marketplace add JuliusBrussee/caveman
+claude plugin install caveman@caveman
+```
+
+## What Gets Installed
+
+1. **Plugin** — `~/.claude/plugins/marketplaces/caveman/`
+2. **Hooks** — Two hooks registered in `~/.claude/settings.json`:
+   - `SessionStart`: `node src/hooks/caveman-activate.js` — reads mode from
+     `~/.claude/.caveman-active`, injects activation prompt
+   - `UserPromptSubmit`: `node src/hooks/caveman-mode-tracker.js` — tracks
+     mode changes, appends context to user prompts
+3. **Hook files** — `~/.claude/hooks/caveman-activate.js`,
+   `caveman-mode-tracker.js`, `caveman-stats.js`, `caveman-config.js`
+4. **Statusline** — PowerShell script `caveman-statusline.ps1` for `[CAVEMAN]`
+   badge in Claude Code status bar
+5. **Flag file** — `~/.claude/.caveman-active` stores current mode (default: `full`)
+
+## Verify Installation
+
+Three checks:
+
+1. **List detected agents:**
+   ```bash
+   node ~/.claude/plugins/marketplaces/caveman/bin/install.js --list
+   ```
+
+2. **Test in Claude Code:** Type `/caveman`. Response should be terse fragments.
+
+3. **Check flag file:**
+   ```bash
+   cat ~/.claude/.caveman-active
+   # expected: full
+   ```
+
+4. **Check settings.json hooks:** Look for `caveman-activate.js` and
+   `caveman-mode-tracker.js` in `hooks` section.
+
+## Statusline Setup
+
+The statusline badge shows `[CAVEMAN]` (orange) in the Claude Code status bar.
+After first `/caveman-stats` run it appends a savings counter like
+`[CAVEMAN] ⛏ 12.4k`.
+
+Add to `~/.claude/settings.json` (or project `.claude/settings.json`):
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -ExecutionPolicy Bypass -File \"C:\\Users\\twc\\.claude\\plugins\\marketplaces\\caveman\\src\\hooks\\caveman-statusline.ps1\""
+  }
+}
+```
+
+> Adjust path if your Windows username differs. The `.ps1` script lives under
+> the caveman plugin directory.
+
+## Modes
+
+| Command | Mode | Effect |
+|---|---|---|
+| `/caveman` | full (default) | Drop articles, fragments OK, short synonyms |
+| `/caveman lite` | lite | Mild compression, keep most structure |
+| `/caveman ultra` | ultra | Maximum compression, near-telegraphic |
+| `/caveman wenyan` | wenyan-lite/full/ultra | Classical Chinese style |
+| `stop caveman` / `normal mode` | off | Revert to normal output |
+
+## Troubleshooting
+
+### Hooks not firing
+
+1. Check `claude` is on PATH: `which claude`
+2. Check `~/.claude/settings.json` has `hooks` with `caveman-activate.js`
+3. Check `~/.claude/.caveman-active` exists with content `full`
+4. Restart Claude Code — SessionStart hook only fires on session start
+
+### Windows-specific
+
+- Use `install.ps1`, not `install.sh`, for hook wiring
+- PowerShell 5.1 minimum: check `$PSVersionTable.PSVersion`
+- If `irm | iex` blocks on execution policy: `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass`
+
+### settings.json mangled
+
+1. Check backup at `~/.claude/settings.json.bak`
+2. Restore from backup or version control
+3. Re-run installer with `--force`
+
+### Managed environment (no hooks)
+
+Use rule-file-only path:
+
+```bash
+node ~/.claude/plugins/marketplaces/caveman/bin/install.js --with-init --only cursor
+```
+
+Drops `.cursor/rules/caveman.mdc` etc. into repo. No hooks, no global config.
+
+## Uninstall
+
+```bash
+npx -y github:JuliusBrussee/caveman -- --uninstall
+```
+
+Removes hooks, plugin, flag file. Does NOT remove:
+- Skills installed via `npx skills add`
+- Per-repo rule files from `--with-init` (delete manually)
+
+## Useful Flags
+
+| Flag | Purpose |
+|---|---|
+| `--dry-run` | Preview commands, write nothing |
+| `--all` | Install everything detected |
+| `--minimal` | Plugin only, no hooks |
+| `--only <id>` | One agent only (e.g. `--only claude`) |
+| `--force` | Re-run even if already installed |
+| `--with-init` | Drop always-on rule files into current repo |
+| `--with-mcp-shrink="<cmd>"` | Register caveman-shrink MCP proxy (opt-in) |
+| `--list` | Print full agent matrix and exit |

--- a/.claude/skills/coding-standard/SKILL.md
+++ b/.claude/skills/coding-standard/SKILL.md
@@ -1,0 +1,661 @@
+---
+name: coding-standard
+description: Huawei CodeArts Check Java coding standards (full reference). Invoke when you need detailed rule descriptions, OK/BAD code examples, or extended rules (concurrency, SQL, collections, performance). Use /coding-standard to load. Keywords: G.NAM, G.ERR, G.CON, G.LOG, G.FMT, code review, rule details, code example. Not applicable to: non-Java code, runtime debugging.
+---
+
+# Java Coding Standards — Full Reference
+
+This skill includes the Java rule set from Huawei Cloud CodeArts Check service. Rule IDs follow the format `G.<prefix>.<number>`, where the prefix corresponds to a topic category. There are 102 rules in total, grouped into 18 topics, each with OK and BAD code examples.
+
+## Engine & Category Notes
+
+| Engine | Category | Description |
+|---|---|---|
+| `fixbotengine-java` | Quality | Huawei's in-house Java inspection engine, covering style/standards/performance (91 rules) |
+| `codemars` | Security | Huawei security defect inspection engine (7 rules) |
+| `secbrella` | Security | Huawei general security inspection engine (4 rules) |
+
+> **Category inference**: Rules from the `codemars` / `secbrella` engines are classified as "Security"; all others are classified as "Quality". Security rules carry higher risk if violated and should be prioritized during Code Review.
+
+## Rule Details
+
+Each rule includes OK and BAD examples, grouped by prefix.
+
+### G.CMT Comments
+
+#### `G.CMT.01` Public or protected elements must have Javadoc comments
+
+#### `G.CMT.02` Top-level public class Javadoc must include functional description + creation date/version
+
+#### `G.CMT.03` Method Javadoc must include functional description, with @param/@return/@throws in order
+
+#### `G.CMT.04` Do not write empty but formatted method header comments
+
+#### `G.CMT.05` File header comments must include copyright/license information
+
+#### `G.CMT.06` Blank line or space between comments and code; space between comment delimiter and content
+
+#### `G.CMT.07` Production code delivered to customers should not contain TODO/FIXME
+
+### G.COL Collections & Generics
+
+#### `G.COL.02` Prefer generic collections over arrays
+
+#### `G.COL.03` Use bounds to restrict available types in generic classes
+
+#### `G.COL.04` Do not use remove/add to modify a collection inside a foreach loop
+
+### G.CON Concurrency
+
+#### `G.CON.01` [Security] Avoid synchronization pitfalls when accessing shared variables
+
+Do not use: (1) synchronized on high-level concurrency objects (Lock/Condition); (2) class objects as locks (ambiguous ownership); (3) reusable objects as locks (Boolean, Integer cache, String constants); (4) public lock objects (DoS risk — use private lock); (5) instance locks to protect static shared data.
+
+#### `G.CON.05` [Security] Do not override a thread-safe method with a non-thread-safe method
+
+Do not override a thread-safe method with a non-thread-safe method
+
+```java
+// OK example
+// Parent class synchronized method, subclass also uses synchronized
+@Override public synchronized void put(String k, String v) { ... }
+// BAD example
+// Parent class synchronized, subclass does not add synchronized
+@Override public void put(String k, String v) { ... }  // Breaks thread safety
+```
+
+#### `G.CON.06` Use new concurrency utilities instead of wait/notify
+
+#### `G.CON.07` When creating a new thread, you must specify a thread name
+
+#### `G.CON.08` Use Thread.setUncaughtExceptionHandler to register an uncaught exception handler
+
+#### `G.CON.09` Do not rely on thread scheduler, thread priority, or yield() — results are non-portable
+
+#### `G.CON.10` Thread interruption should be handled cooperatively by business code; use Thread.interrupt with caution
+
+#### `G.CON.11` [Security] Do not use Thread.stop() to terminate a thread — it releases all locks unsafely
+
+#### `G.CON.12` Avoid creating new threads without control; use thread pools instead
+
+### G.CTL Control Flow
+
+#### `G.CTL.01` Do not perform assignments or complex evaluations in control condition expressions
+
+#### `G.CTL.02` Conditional statements with else-if branches should have an else branch at the end
+
+#### `G.CTL.03` switch statements must have a default branch
+
+#### `G.CTL.05` Avoid modifying the loop control variable inside the loop body
+
+### G.DCL Declarations
+
+#### `G.DCL.01` Declare one variable per line
+
+#### `G.DCL.02` Declare local variables close to their first use to minimize scope
+
+#### `G.DCL.03` C-style array declarations are prohibited (brackets after the variable name)
+
+#### `G.DCL.04` Avoid relying on ordinal() for enum constant ordering
+
+#### `G.DCL.05` Do not define mutable objects as constants
+
+### G.EDV XML Security
+
+#### `G.EDV.05` [Security] Prevent XML External Entity (XXE) attacks when parsing external XML
+
+#### `G.EDV.06` [Security] Prevent XML Entity Expansion attacks when parsing external XML
+
+#### `G.EDV.07` [Security] Do not use unsafe XSLT transformations on XML files
+
+### G.ERR Exception Handling
+
+#### `G.ERR.01` Do not ignore exceptions with an empty catch block
+
+Do not ignore exceptions with an empty catch block
+
+```java
+// OK example
+try { ... } catch (IOException e) { log.error("File read failed", e); throw new RuntimeException(e); }
+// BAD example
+try { ... } catch (IOException e) {}  // Exception is swallowed
+```
+
+#### `G.ERR.02` Do not catch the base exception classes Throwable, Exception, or RuntimeException directly
+
+Do not catch Throwable/Exception/RuntimeException directly
+
+```java
+// OK example
+catch (FileNotFoundException e) { ... }
+// BAD example
+catch (Exception e) { ... }  // Too broad
+```
+
+#### `G.ERR.03` Do not catch RuntimeExceptions that can be handled by pre-checks (e.g., NullPointerException, IndexOutOfBoundsException)
+
+#### `G.ERR.04` [Security] Prevent leaking sensitive information through exceptions
+
+Prevent leaking sensitive information through exceptions
+
+```java
+// OK example
+catch (AuthException e) { log.error("Authentication failed", e); throw new BizException("Authentication failed"); }
+// BAD example
+catch (AuthException e) { throw new RuntimeException("Password error: " + password); }  // Leaks password
+```
+
+#### `G.ERR.05` Exceptions thrown by a method should match its level of abstraction
+
+#### `G.ERR.06` [Security] When throwing a new exception in catch, pass the original exception as the cause
+
+When throwing a new exception in catch, pass the original exception as the cause
+
+```java
+// OK example
+catch (SQLException e) { throw new ServiceException("Query failed", e); }
+// BAD example
+catch (SQLException e) { throw new ServiceException("Query failed"); }  // Loses root cause
+```
+
+#### `G.ERR.07` A method should not throw more than 5 exceptions; document each in @throws
+
+#### `G.ERR.08` [Security] Do not use return/break/continue/throw to cause finally to exit abnormally
+
+Do not use return/break/continue/throw to cause finally to exit abnormally
+
+```java
+// OK example
+try { return compute(); }
+finally { cleanup(); }  // finally only does cleanup
+// BAD example
+try { return compute(); }
+finally { return -1; }  // finally uses return, overriding the return value
+```
+
+#### `G.ERR.09` [Security] Do not call System.exit() to terminate the JVM
+
+Do not call System.exit() to terminate the JVM
+
+```java
+// OK example
+throw new StartupException("Cannot start, please check configuration");  // Let the caller handle it
+// BAD example
+System.exit(1);  // Forced termination, affects the caller
+```
+
+#### `G.ERR.10` Eliminate unchecked exceptions as much as possible; do not use SuppressWarning on an entire class
+
+#### `G.ERR.11` GeneralSecurityException and its subclasses should be logged
+
+### G.EXP Expressions
+
+#### `G.EXP.01` Do not assign to the same variable more than once in a single expression
+
+#### `G.EXP.02` Use parentheses to clarify expression evaluation order; do not rely on default precedence
+
+#### `G.EXP.03` The 2nd and 3rd operands of a conditional expression ?: should be the same type
+
+#### `G.EXP.04` Expression comparisons: left side tends to vary, right side tends to be constant; use equals for String comparison
+
+#### `G.EXP.06` [Security] Assertions (assert) should not be used in code
+
+Assertions (assert) should not be used in code
+
+```java
+// OK example
+if (input == null) throw new IllegalArgumentException("input null");
+// BAD example
+assert input != null;  // Disabled by default in production, has no effect
+```
+
+### G.FIO File IO
+
+#### `G.FIO.01` [Security] File paths constructed from external data must be validated and normalized before use
+
+File paths constructed from external data must be validated and normalized before use
+
+```java
+// OK example
+Path base = Paths.get("/safe/base").normalize().toAbsolutePath();
+Path resolved = base.resolve(userInput).normalize();
+if (!resolved.startsWith(base)) throw new SecurityException("Path traversal");
+// BAD example
+File f = new File(userInput);  // Not validated, possible path traversal
+```
+
+#### `G.FIO.02` [Security] ZipInputStream entries must be security-checked before extraction (path traversal + zip bomb)
+
+#### `G.FIO.03` [Security] Use int return type for single byte/char reads from streams (InputStream.read/Reader.read)
+
+#### `G.FIO.04` [Security] Prevent external process blocking on input/output streams (drain stdout/stderr)
+
+### G.FMT Formatting
+
+#### `G.FMT.01` Source file encoding must be UTF-8
+
+#### `G.FMT.02` A source file contains copyright, package, import, top-level class in order, separated by blank lines
+
+#### `G.FMT.03` Import order: static imports first, then Android, Huawei, commercial, open-source, net/org, Java — grouped by blank lines
+
+#### `G.FMT.04` Class member order: class variables, static init blocks, instance variables, instance init blocks, constructors, methods — separated by blank lines
+
+#### `G.FMT.05` Braces must be used in conditional statements and loop blocks
+
+#### `G.FMT.06` Non-empty blocks: left brace at end of line, right brace on a new line
+
+#### `G.FMT.07` Avoid empty blocks; when an empty block is necessary, use a consistent brace-newline style
+
+Avoid empty blocks; when necessary, use a consistent brace-newline style
+
+```java
+// OK example
+// Add a comment explaining why it is empty
+if (cond) {
+    // Intentionally left empty, see ISSUE-123
+}
+// BAD example
+if (cond) {}  // Empty block without comment
+```
+
+#### `G.FMT.08` Use spaces for indentation, 4 spaces per level (no tabs)
+
+#### `G.FMT.09` No more than one statement per line
+
+#### `G.FMT.10` Line width should not exceed 120 narrow characters
+
+#### `G.FMT.11` Line breaks should start before the operator
+
+#### `G.FMT.12` Reduce unnecessary blank lines; keep code compact
+
+#### `G.FMT.13` Use spaces to highlight keywords and important information
+
+#### `G.FMT.14` Do not insert extra spaces to vertically align code
+
+#### `G.FMT.15` Enum constants separated by commas; line breaks optional
+
+#### `G.FMT.16` When a case block ends without break, a comment must explain the fall-through
+
+#### `G.FMT.17` Each annotation on a class, method, or class field should be on its own line
+
+#### `G.FMT.18` Block comment indentation should match the surrounding code
+
+#### `G.FMT.19` Class and member modifiers should follow the order recommended by the Java Language Specification
+
+#### `G.FMT.20` Numeric literals should have appropriate suffixes; long types should use L
+
+### G.LOG Logging
+
+#### `G.LOG.01` Use the Facade pattern for logging (SLF4J), not Log4j/Logback directly
+
+#### `G.LOG.02` Logger instances must be declared as private static final
+
+#### `G.LOG.03` Logs must be leveled (DEBUG/INFO/WARN/ERROR)
+
+#### `G.LOG.04` Products not exclusively sold in Chinese-speaking regions must not use Chinese in log messages
+
+### G.MET Methods
+
+#### `G.MET.01` Methods should be short; parameters should not exceed 5
+
+#### `G.MET.03` Method parameters should not be used as temporary variables
+
+#### `G.MET.04` Use varargs with caution
+
+#### `G.MET.05` Methods returning arrays or collections should return empty collections, not null
+
+#### `G.MET.06` Use Optional instead of null for possibly missing return values; assigning null to Optional is prohibited
+
+#### `G.MET.07` [Security] Do not ignore method return values
+
+### G.NAM Naming
+
+#### `G.NAM.01` Identifiers should not exceed 64 characters, consisting of letters, digits, and underscores
+
+#### `G.NAM.02` Package names should be lowercase, with dots separating levels
+
+#### `G.NAM.03` Class, enum, and interface names should use PascalCase
+
+Class, enum, and interface names use PascalCase
+
+```java
+// OK example
+public class OrderService {}
+// BAD example
+public class order_service {}  // Underscore style
+```
+
+#### `G.NAM.04` Method names should use camelCase
+
+Method names use camelCase
+
+```java
+// OK example
+public String getUserName() {}
+// BAD example
+public String get_user_name() {}
+```
+
+#### `G.NAM.05` Constant names should be ALL_UPPERCASE with underscores separating words
+
+Constant names are ALL_UPPERCASE with underscores between words
+
+```java
+// OK example
+static final int MAX_RETRY = 3;
+// BAD example
+static final int maxRetry = 3;
+```
+
+#### `G.NAM.06` Variables use camelCase
+
+#### `G.NAM.07` Avoid boolean variable names with negative meanings
+
+#### `G.NAM.08` Boolean variables should start with a verb expressing a true/false meaning
+
+### G.OBJ Classes & Objects
+
+#### `G.OBJ.01` Avoid defining public and non-final class fields
+
+#### `G.OBJ.02` Do not call overridable methods in a parent class constructor
+
+#### `G.OBJ.03` When there are multiple constructors, reuse them as much as possible
+
+#### `G.OBJ.04` Avoid reusing names across unrelated variables or concepts; avoid hiding/shadowing/obscuring
+
+#### `G.OBJ.05` Avoid overloading methods with the same name between primitive and wrapper types
+
+#### `G.OBJ.06` When overriding equals, you must also override hashCode
+
+When overriding equals, you must also override hashCode
+
+```java
+// OK example
+@Override public boolean equals(Object o) { ... }
+@Override public int hashCode() { ... }
+// BAD example
+@Override public boolean equals(Object o) { ... }  // No hashCode, HashMap will break
+```
+
+#### `G.OBJ.07` Override methods must have @Override annotation
+
+#### `G.OBJ.08` Implement the Singleton pattern correctly
+
+#### `G.OBJ.09` [Security] Use class name to call static methods, not instances or expressions
+
+#### `G.OBJ.10` Remove redundant modifiers from interface definitions
+
+### G.OTH Other
+
+#### `G.OTH.01` [Security] Use cryptographically secure random numbers in security contexts
+
+#### `G.OTH.02` [Security] Use SSLSocket instead of Socket for secure data exchange
+
+#### `G.OTH.03` Unused code segments (including imports) should be deleted, not commented out
+
+#### `G.OTH.04` [Security] Do not include public network addresses (IP/URL/email) in code
+
+#### `G.OTH.05` [Security] Remove invalid or never-executed code
+
+```java
+// OK example
+// Only keep code that will execute
+// BAD example
+if (false) { deadCode(); }  // Never executes
+return; doCleanup();  // Dead code after return
+```
+
+### G.PRM Performance
+
+#### `G.PRM.01` Use Collection.toArray(T[]) for collection-to-array; after Java 11, use toArray(IntFunction)
+
+#### `G.PRM.02` Use System.arraycopy or Arrays.copyOf for array copying
+
+#### `G.PRM.04` Do not repeatedly pre-compile the same regular expression
+
+#### `G.PRM.05` Do not create unnecessary objects
+
+Do not create unnecessary objects
+
+```java
+// OK example
+Boolean enabled = Boolean.TRUE;  // Or directly boolean enabled = true;
+String s = "literal";
+// BAD example
+Boolean enabled = new Boolean(true);  // New object each time
+String s = new String("literal");
+```
+
+#### `G.PRM.07` IO operations must close resources in try-with-resources or finally
+
+#### `G.PRM.08` Explicit GC calls are prohibited (except for passwords/RMI, etc.), especially in frequent/periodic logic
+
+#### `G.PRM.09` The Finalizer mechanism is prohibited
+
+#### `G.PRM.10` Do not create temporary variables just for a return statement
+
+### G.SEC Security
+
+#### `G.SEC.01` [Security] Security-check methods must be declared private or final
+
+#### `G.SEC.02` [Security] Custom ClassLoader overriding getPermissions() must call super.getPermissions() first
+
+#### `G.SEC.04` [Security] Use a security manager to protect sensitive operations
+
+### G.SER Serialization
+
+#### `G.SER.01` Avoid implementing Serializable when possible
+
+#### `G.SER.02` Classes implementing Serializable should explicitly declare serialVersionUID
+
+#### `G.SER.04` Do not directly serialize information pointing to system resources
+
+#### `G.SER.05` [Security] Do not serialize non-static inner classes
+
+#### `G.SER.07` [Security] Prevent deserialization from bypassing constructor security checks
+
+### G.TYP Types
+
+#### `G.TYP.03` Do not use floating-point numbers as loop counters
+
+#### `G.TYP.04` Use BigDecimal for exact calculations; do not use float/double
+
+#### `G.TYP.05` Do not use == directly for floating-point equality; do not use equals for wrapper types
+
+#### `G.TYP.06` Do not compare with NaN; use isNaN()
+
+#### `G.TYP.07` Do not hardcode line separators or file path separators; use constants
+
+#### `G.TYP.08` String case conversion and number formatting must specify Locale.ROOT or Locale.ENGLISH
+
+#### `G.TYP.09` Character-to-byte conversions must specify the encoding
+
+#### `G.TYP.11` Prefer primitive types over wrapper types; use wrapper types judiciously
+
+#### `G.TYP.12` Perform type conversions explicitly; avoid implicit conversions
+
+#### `G.TYP.13` Use instanceof to check before downcasting a reference type
+
+## Extended Rules (High-frequency issues not covered by the Huawei 102 rules)
+
+The following are issues that frequently appear in Java Code Reviews but are not covered by the Huawei CodeArts Check rule set. Rule IDs use the `X.` prefix to distinguish them from `G.*`. Rules with OK/BAD examples are listed separately; the rest are in tables.
+
+### Testing Standards
+
+| Rule ID | Rule Summary |
+|---|---|
+| `X.TST.01` | Test methods must not share state (`static` fields); each test should be independent |
+| `X.TST.02` | Tests must have effective assertions, not just `assertNotNull`; assertions should cover core business logic |
+| `X.TST.03` | Avoid mocking static methods (PowerMock); prefer refactoring code to make dependencies injectable |
+| `X.TST.04` | Integration tests (depending on DB/HTTP) must be tagged with `@Tag("integration")` or similar, separated from unit tests |
+| `X.TST.05` | Test class names should correspond to the class under test: `UserService` -> `UserServiceTest`; method names `methodName_scenario_expected` |
+| `X.TST.06` | Test three-part structure: Given (setup) -> When (execute) -> Then (assert), separated by blank lines |
+
+### SQL & Database
+
+| Rule ID | Rule Summary |
+|---|---|
+| `X.SQL.01` | SQL concatenation is prohibited; use PreparedStatement or parameterized queries |
+| `X.SQL.02` | Queries on large tables must be paginated (`LIMIT/OFFSET` or `WHERE id > lastId` cursor pagination) |
+| `X.SQL.03` | `WHERE` condition fields must have indexes to avoid full table scans; composite indexes must follow the leftmost prefix rule |
+| `X.SQL.04` | `SELECT *` is prohibited; specify column names explicitly to reduce IO and avoid mapping errors when columns change |
+| `X.SQL.05` | Use batch for bulk operations, not single inserts in a loop (`addBatch()` or MyBatis `<foreach>`) |
+| `X.SQL.06` | Minimize transaction scope; do not make RPC calls or perform expensive computations inside transactions |
+| `X.SQL.07` | Avoid large/long transactions that hold locks and connection pool resources; use `@Transactional(timeout=...)` to set an upper bound |
+
+#### `X.SQL.01` SQL concatenation is prohibited; use PreparedStatement or parameterized queries
+
+```java
+// OK example
+// PreparedStatement parameterized
+String sql = "SELECT id, name FROM user WHERE name = ? AND status = ?";
+try (PreparedStatement ps = conn.prepareStatement(sql)) {
+    ps.setString(1, name);
+    ps.setInt(2, status);
+    try (ResultSet rs = ps.executeQuery()) { ... }
+}
+// MyBatis: use #{} not ${}
+// <select id="findByName">SELECT ... WHERE name = #{name}</select>
+// BAD example
+// String concatenation, SQL injection risk
+String sql = "SELECT id, name FROM user WHERE name = '" + name + "' AND status = " + status;
+Statement st = conn.createStatement();
+ResultSet rs = st.executeQuery(sql);  // name containing ' OR '1'='1 enables injection
+// MyBatis: ${} is string concatenation, equally dangerous
+// <select id="findByName">SELECT ... WHERE name = '${name}'</select>
+```
+
+### Concurrency Details (not covered by Huawei G.CON)
+
+| Rule ID | Rule Summary |
+|---|---|
+| `X.CON.03` | `synchronized` must not lock String literals, Integer cache objects, or Boolean; lock `new Object()` or a dedicated lock object |
+| `X.CON.05` | `HashMap` concurrent writes by multiple threads can cause infinite loops (JDK7 linked list cycle) or data loss; use `ConcurrentHashMap` |
+
+#### `X.CON.01` SimpleDateFormat is not thread-safe; use DateTimeFormatter or ThreadLocal in multi-threaded contexts
+
+```java
+// OK example
+// 1: DateTimeFormatter (JDK8+, thread-safe)
+private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+String s = LocalDate.now().format(FMT);
+
+// OK example 2: ThreadLocal wrapper (compatible with legacy code)
+private static final ThreadLocal<SimpleDateFormat> TL =
+    ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd"));
+String s = TL.get().format(new Date());
+// BAD example
+// static SimpleDateFormat shared across threads
+private static final SimpleDateFormat FMT = new SimpleDateFormat("yyyy-MM-dd");
+// Multiple threads calling FMT.format() will overwrite each other's Calendar internal state, causing incorrect results
+// Symptom: occasionally parsing 1970 or throwing NumberFormatException
+```
+
+#### `X.CON.02` Double-checked locking must use volatile to prevent instruction reordering
+
+```java
+// OK example
+// instance with volatile
+public class Singleton {
+    private static volatile Singleton instance;
+    public static Singleton getInstance() {
+        if (instance == null) {
+            synchronized (Singleton.class) {
+                if (instance == null) {
+                    instance = new Singleton();
+                }
+            }
+        }
+        return instance;
+    }
+}
+// BAD example
+// Missing volatile
+public class Singleton {
+    private static Singleton instance;  // Missing volatile
+    public static Singleton getInstance() {
+        if (instance == null) {           // Thread B may read a half-initialized object
+            synchronized (Singleton.class) {
+                if (instance == null) {
+                    instance = new Singleton();  // Instruction reordering: assignment before field initialization
+                }
+            }
+        }
+        return instance;  // Other threads get an "initialized" object whose fields are still null
+    }
+}
+```
+
+#### `X.CON.04` Use computeIfAbsent instead of get+put with ConcurrentHashMap to ensure atomicity
+
+```java
+// OK example
+// computeIfAbsent atomic operation
+ConcurrentMap<String, List<String>> map = new ConcurrentHashMap<>();
+map.computeIfAbsent(key, k -> new ArrayList<>()).add(value);  // Done in one step
+
+// OK example: putIfAbsent (alternative to get+put)
+List<String> list = new ArrayList<>();
+List<String> old = map.putIfAbsent(key, list);
+if (old != null) { list = old; }
+list.add(value);
+// BAD example
+// get + put is not atomic; data loss under concurrent access
+ConcurrentMap<String, List<String>> map = new ConcurrentHashMap<>();
+List<String> list = map.get(key);      // Threads A and B both get null
+if (list == null) {
+    list = new ArrayList<>();
+    map.put(key, list);                 // Threads A and B each put one; A's is overwritten
+}
+list.add(value);  // Thread A adds to its own list, but map contains B's
+```
+
+#### `X.CON.06` Thread pools must be created explicitly with ThreadPoolExecutor; Executors convenience methods are prohibited
+
+```java
+// OK example
+// Explicit ThreadPoolExecutor with controllable parameters
+ExecutorService pool = new ThreadPoolExecutor(
+    8,                              // corePoolSize
+    16,                             // maxPoolSize
+    60L, TimeUnit.SECONDS,          // keepAliveTime
+    new LinkedBlockingQueue<>(1000),// Bounded queue, prevents OOM
+    new ThreadFactoryBuilder().setNameFormat("order-pool-%d").build(),  // Named threads
+    new ThreadPoolExecutor.CallerRunsPolicy()  // Rejection policy: caller runs
+);
+// BAD example
+// Executors convenience methods have significant risks
+ExecutorService pool1 = Executors.newCachedThreadPool();   // Unbounded thread count, may create tens of thousands of threads
+ExecutorService pool2 = Executors.newFixedThreadPool(8);   // Unbounded queue, task accumulation causes OOM
+ExecutorService pool3 = Executors.newSingleThreadExecutor(); // Same as newFixedThreadPool(1), unbounded queue
+
+// Problem: queues are SynchronousQueue (unbounded) / LinkedBlockingQueue (unbounded); task accumulation leads to OOM
+```
+
+### Collection Details (not covered by Huawei G.COL)
+
+| Rule ID | Rule Summary |
+|---|---|
+| `X.COL.01` | `Arrays.asList()` returns a fixed-size list; `add/remove` throws `UnsupportedOperationException`; for a mutable list use `new ArrayList<>(Arrays.asList(...))` |
+| `X.COL.02` | `subList()` returns a view; modifications affect the original list; for an independent copy use `new ArrayList<>(list.subList(...))` |
+| `X.COL.03` | Use `isEmpty()` instead of `size() == 0` for collection emptiness checks; clearer semantics |
+| `X.COL.04` | Using `LinkedList` with random access `get(i)` is O(n); use `ArrayList` for random access |
+
+### Performance Details (not covered by Huawei G.PRM)
+
+| Rule ID | Rule Summary |
+|---|---|
+| `X.PRM.01` | Do not call DB or RPC inside loops; use batch processing or preloading |
+| `X.PRM.02` | Use `StringBuilder` for string concatenation in loops, not `+=` (creates a new object each time) |
+| `X.PRM.03` | Do not traverse a `Stream` multiple times: `list.stream().count()` then `collect` again; complete in one pass |
+| `X.PRM.04` | `String.matches("...")` recompiles the regex each time; use `Pattern.compile` with a static cache |
+| `X.PRM.05` | Avoid creating large objects in hot paths (e.g., `new ArrayList<>(hugeCapacity)` inside a loop) |
+
+### Dependencies & Build
+
+| Rule ID | Rule Summary |
+|---|---|
+| `X.DEP.01` | Dependency versions should be unified in the parent pom's `<dependencyManagement>`; submodules should not specify version |
+| `X.DEP.02` | Do not import large libraries like `commons-lang3` just to use one method; write it by hand or find a lightweight alternative |
+| `X.DEP.03` | The `provided` scope is only for container-provided dependencies (e.g., Servlet API); do not use provided for runtime-needed dependencies |
+| `X.DEP.04` | Avoid circular dependencies: A depends on B, B depends on A; refactor to extract a shared module |

--- a/.claude/skills/jvm-troubleshoot/SKILL.md
+++ b/.claude/skills/jvm-troubleshoot/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: jvm-troubleshoot
+description: JVM production troubleshooting handbook. Actively applied when an application reports OOM, CPU 100%, frequent GC, thread deadlock, class loading leak, startup failure, response lag, JVM killed inside a container, or module system reflection failure. Keywords: OOM, OutOfMemoryError, CPU high, GC, Full GC, deadlock, jstack, jmap, jstat, JVM tuning, Metaspace, StackOverflow, OOMKilled, container, cgroup, PID 1, JRE-only, InaccessibleObjectException, --add-opens, module system, JPMS. Not applicable to: coding standard issues (use coding-standard), agent team assembly (use agent-team-guide), non-JVM failures, proactive performance tuning and JVM parameter selection (use performance-tuning).
+---
+
+# JVM Production Troubleshooting Handbook
+
+This skill is organized by "symptom -> diagnostic workflow -> root cause table -> fix", covering 7 categories of high-frequency JVM failures. All commands require first running `jps -lvm` to obtain the `<pid>`.
+
+**Boundary with performance-tuning**:
+- jvm-troubleshoot (this skill): reactive troubleshooting (OOM/CPU 100% has already occurred) -> follow "symptom -> diagnosis -> fix"
+- performance-tuning: proactive optimization (selecting GC before deployment, tuning JVM parameters, writing high-performance code) -> follow "layer -> selection -> optimization -> verification"
+
+## Failure Category Quick Reference
+
+| Symptom | Jump to |
+|---|---|
+| Application reports `OutOfMemoryError` | [OOM Troubleshooting](#oom-troubleshooting) |
+| CPU usage at 100% | [CPU Troubleshooting](#cpu-100-troubleshooting) |
+| Frequent GC, application lag | [High-Frequency GC Troubleshooting](#high-frequency-gc-troubleshooting) |
+| Slow response, timeout, no error | [Performance Troubleshooting](#performance-troubleshooting) |
+| Thread deadlock, program stuck | [Thread Deadlock Troubleshooting](#thread-deadlock-troubleshooting) |
+| `ClassNotFoundException` / `NoClassDefFoundError` | [Class Loading Troubleshooting](#class-loading-troubleshooting) |
+| `InaccessibleObjectException` / module system reflection failure | [Module System Troubleshooting](#module-system-troubleshooting) |
+| JVM startup failure, immediate exit | [Startup Failure Troubleshooting](#startup-failure-troubleshooting) |
+| JVM killed inside container / `jps` cannot see / JRE-only | [Container Troubleshooting](#container-troubleshooting) |
+
+## OOM Troubleshooting
+
+OOM types and identification:
+
+| OOM Type | Error Keyword | Root Cause | Troubleshooting |
+|---|---|---|---|
+| **Java heap space** | `OutOfMemoryError: Java heap space` | Heap memory insufficient, objects not released | `jmap -dump` to get dump -> MAT to analyze large objects -> check static Map/list for continuous growth |
+| **GC overhead** | `GC overhead limit exceeded` | GC spending too much time reclaiming too little memory | Same as above; usually a memory leak or heap too small |
+| **Metaspace** | `OutOfMemoryError: Metaspace` | Too much class metadata (dynamically generated classes, ClassLoader leak) | Adjust `-XX:MaxMetaspaceSize`; check dynamic proxies/CGLIB; see [Class Loading Troubleshooting](#class-loading-troubleshooting) |
+| **Direct buffer** | `OutOfMemoryError: Direct buffer memory` | NIO direct memory not released | Check `ByteBuffer.allocateDirect` release; adjust `-XX:MaxDirectMemorySize` |
+| **StackOverflow** | `StackOverflowError` | Recursion too deep or stack frame too large | Check recursion termination condition; adjust `-Xss` to increase stack (symptomatic, not root fix) |
+| **unable to create thread** | `OutOfMemoryError: unable to create new native thread` | Thread count reached OS limit | `jstack` to see thread count; check thread pool leak; adjust `ulimit -u` |
+
+**Stop the bleeding**: First enable `-XX:+HeapDumpOnOutOfMemoryError` to get a dump, then restart. **Root fix**: Use MAT to analyze the dump, find the GC Root chain, and locate the leak point.
+
+## CPU 100% Troubleshooting
+
+**Diagnostic workflow** (4-step identification):
+
+1. `top` to find the **process** PID with high CPU usage
+2. `top -Hp <pid>` to find the **thread** TID with high CPU usage (decimal)
+3. `printf "%x\n" <tid>` to convert to hexadecimal
+4. `jstack <pid> | grep <hexadecimal tid> -A 30` to see what the thread is doing
+
+**Common root causes**:
+
+| Root Cause | Manifestation | Countermeasure |
+|---|---|---|
+| Infinite loop / infinite recursion | jstack stack frames repeating or fixed | Fix code logic, add termination condition |
+| Regex catastrophic backtracking | Stack in `Pattern.matcher` | Simplify regex, or use pre-compiled + timeout |
+| Large nested collection iteration | Stack in `for` / `Stream` | Change algorithm, reduce O(n^2) to O(n) |
+| Serializing large objects | Stack in `ObjectOutputStream` | Limit object size, or use streaming processing |
+| GC threads consuming all CPU | Multiple `GC task` threads with high CPU | Actually a memory issue, see [High-Frequency GC Troubleshooting](#high-frequency-gc-troubleshooting) |
+| Intensive crypto hashing | Stack in `MessageDigest` | Use a faster algorithm, or execute asynchronously |
+
+**Note**: If CPU is high but business logic is not complex, first check whether GC threads are consuming all CPU (check GC logs).
+
+## High-Frequency GC Troubleshooting
+
+**Diagnostic workflow**:
+
+1. Enable GC logs: `-Xlog:gc*:file=gc.log:time,uptime:filecount=10,filesize=10M` (JDK9+)
+2. Analyze logs with GCViewer or gceasy.io
+3. Check key metrics:
+   - **Full GC frequency**: Normal is once every few hours; once every few minutes is problematic
+   - **GC throughput**: GC time ratio should be < 5%; > 10% requires investigation
+   - **Old generation occupancy**: Continuously growing without dropping = memory leak
+4. `jstat -gcutil <pid> 1000` to observe occupancy changes across generations
+
+**Common root causes and countermeasures**:
+
+| Root Cause | Countermeasure |
+|---|---|
+| Heap too small | Increase `-Xmx` |
+| Object creation too fast | Caching, object pool, `StringBuilder` |
+| Memory leak | Get dump to find leak point (see OOM Troubleshooting) |
+| Large objects promoted directly to old generation | Adjust `-XX:PretenureSizeThreshold` |
+| Metaspace insufficient | Adjust `-XX:MaxMetaspaceSize` (see OOM Metaspace) |
+| `System.gc()` being called | Add `-XX:+DisableExplicitGC` to disable |
+
+**GC collector selection and production parameter configuration**: Proactive configuration belongs to the performance-tuning skill, see `../performance-tuning/references/gc_tuning.md`. This skill only covers reactive troubleshooting.
+
+## Performance Troubleshooting
+
+When response is slow but CPU is not high and GC is normal:
+
+1. `jstack <pid> > thread.txt` to see thread state distribution
+2. Count `BLOCKED` / `WAITING` threads: `grep "java.lang.Thread.State" thread.txt | sort | uniq -c`
+3. Many `BLOCKED` -> lock contention, see [Thread Deadlock Troubleshooting](#thread-deadlock-troubleshooting)
+4. Many `WAITING` -> thread pool idle or waiting for external resources (DB/HTTP)
+5. Check if threads are stuck in `SocketRead` -> RPC timeout or slow peer
+6. `jstat -gcutil <pid> 1000` to rule out GC issues
+
+## Thread Deadlock Troubleshooting
+
+**Diagnosis**: `jstack <pid> | grep -A 20 "Found Java deadlock"` -- jstack automatically detects synchronized deadlocks and prints them.
+
+**synchronized deadlock**:
+- Manifestation: `jstack` reports "Found 1 deadlock", two threads waiting for each other's lock
+- Root cause: Nested `synchronized` blocks with inconsistent lock ordering
+- Fix: Unify lock ordering, or use `tryLock(timeout)`
+
+**Lock deadlock (ReentrantLock)**:
+- Manifestation: Thread `WAITING` in `AbstractQueuedSynchronizer`, but jstack **does not report deadlock** (Lock deadlocks are not automatically detected)
+- Diagnosis: Check `jstack` stack for threads stuck in `lock()` calls
+- Fix: Use `tryLock(timeout, unit)` instead of `lock()`, release and retry on timeout
+
+**Thread leak (pseudo-deadlock)**:
+- Manifestation: Thread count keeps growing, eventually `unable to create thread`
+- Diagnosis: `jstack <pid> | grep "java.lang.Thread.State" | wc -l` to count total threads
+- Fix: Check if thread pool is leaking (`new Thread` not in a pool, `submit` without `shutdown`)
+
+## Class Loading Troubleshooting
+
+`ClassNotFoundException` / `NoClassDefFoundError` / `LinkageError`:
+
+1. `jmap -clstats <pid>` to see ClassLoader count and loaded class count
+2. Abnormally many ClassLoaders -> ClassLoader leak (common in hot deployment, dynamic proxies)
+3. Class not found -> check classpath: `jcmd <pid> VM.classloader_stats`
+4. Same class with multiple version conflicts -> `jmap -clstats` to see if multiple ClassLoaders load the same class
+
+**Metaspace leak**:
+- Symptom: Metaspace does not drop after Full GC, eventually OOM Metaspace
+- Diagnosis: `jmap -clstats <pid>` to see if ClassLoader count keeps growing
+- Root cause: Dynamic proxies (CGLIB/ByteBuddy) generating new classes each time without caching, or web container hot deployment not cleaning up old ClassLoaders
+- Fix: Cache proxy classes, fix hot deployment leak, adjust `-XX:MaxMetaspaceSize`
+
+## Module System Troubleshooting
+
+Failures specific to JDK 9+ module system (JPMS). Guaranteed to encounter on JDK 17.
+
+### InaccessibleObjectException
+
+**Symptom**: Reflection call reports `java.lang.reflect.InaccessibleObjectException: Unable to make field accessible: module java.base does not "opens java.lang" to unnamed module`
+
+**Root cause**: JDK 9+ module system protects non-exported packages; reflection access requires explicit opening.
+
+**Troubleshooting**:
+1. Check which line of the error mentions "module X does not opens Y"
+2. Add the corresponding `--add-opens` for that module
+
+**Common `--add-opens` quick reference**:
+
+| Scenario | Error Module | Parameter |
+|---|---|---|
+| Reflective access to `String` internals | `java.base/java.lang` | `--add-opens java.base/java.lang=ALL-UNNAMED` |
+| Reflective access to collection internals | `java.base/java.util` | `--add-opens java.base/java.util=ALL-UNNAMED` |
+| Netty NIO access | `java.base/java.nio` | `--add-opens java.base/java.nio=ALL-UNNAMED` |
+| Reflective access to `Method` | `java.base/java.lang.reflect` | `--add-opens java.base/java.lang.reflect=ALL-UNNAMED` |
+| Kryo / Gson serialization | `java.base/java.lang` etc. | Usually requires multiple `--add-opens` |
+| Spring / Hibernate reflection | Multiple | See framework documentation |
+
+**Configuration location**:
+- Command line: `java --add-opens ... -jar app.jar`
+- MANIFEST.MF: `Add-Opens: java.base/java.lang java.base/java.util`
+- K8s: `JAVA_OPTS` environment variable
+
+### `--add-opens` vs `--add-exports`
+
+| Parameter | Purpose |
+|---|---|
+| `--add-opens` | Reflective access (open at runtime) |
+| `--add-exports` | Compile-time + runtime access (non-reflective) |
+| `--add-reads` | Let one module read another module |
+
+**Choose**: Use `--add-opens` for reflection scenarios; use `--add-exports` for direct imports.
+
+### Module Conflict
+
+**Symptom**: Startup reports `Module resolution failed` or `module not found`.
+
+**Troubleshooting**:
+- Check if there are multiple versions of the same module
+- Check module-path (`--module-path`) vs classpath
+- Use `java --list-modules` to see loaded modules
+
+### Module System Diagnostic Commands
+
+```bash
+# View module system parameters
+jcmd <pid> VM.system_properties | grep jdk.module
+
+# View loaded modules
+java --list-modules
+
+# Startup debugging
+java --show-module-resolution -jar app.jar
+```
+
+## Container Troubleshooting
+
+JVM failures specific to K8s / Docker containers. For detailed troubleshooting see `references/container_troubleshooting.md`.
+
+**Quick reference**:
+
+| Symptom | Root Cause | Countermeasure |
+|---|---|---|
+| Pod `OOMKilled` exit 137 | cgroup memory < JVM usage | Use `MaxRAMPercentage` instead of fixed `-Xmx` |
+| `jps` cannot see JVM | Container main process is PID 1 | Use `jcmd 1 ...` |
+| `jcmd` command not found | JRE-only image | Sidecar with JDK / use jattach / use JFR |
+| `Could not reserve enough space` | `-Xmx` exceeds cgroup | Use `MaxRAMPercentage=75.0` |
+| `unable to create new native thread` | Container ulimit tightened | Adjust `ulimit -u` or reduce thread count |
+| JFR / dump lost on disk | Container path not mounted | Mount PVC to `HeapDumpPath` |
+
+## Startup Failure Troubleshooting
+
+JVM exits immediately on startup; check the error keyword:
+
+| Error | Root Cause | Countermeasure |
+|---|---|---|
+| `Could not reserve enough space for object heap` | `-Xmx` exceeds physical memory | Reduce `-Xmx`, or check if other processes are using memory |
+| `Invalid initial heap size` | `-Xms` / `-Xmx` parameter format error | Check parameter units (`4g` not `4096`) |
+| `Incompatible version` | Compile-time JDK version > runtime | Run with same or higher JDK |
+| `Unsupported major.minor version` | Class file version mismatch | Use `javap -verbose X.class` to check major version |
+| `Unable to open jar` | Jar file corrupted or wrong path | Check `-jar` path and jar integrity |
+| `Error: LinkageError` | Class conflict | Check classpath for duplicate classes |
+
+## Command Quick Reference
+
+JVM diagnostic commands organized by scenario:
+
+```bash
+# === Process Overview ===
+jps -lvm                                      # List JVM processes
+jcmd <pid> VM.flags                           # View JVM startup parameters
+jcmd <pid> VM.system_properties               # View system properties
+
+# === Heap Analysis ===
+jmap -heap <pid>                              # Heap overview (generation occupancy)
+jmap -histo:live <pid> | head -20             # Large object histogram (top 20)
+jmap -dump:format=b,file=heap.hprof <pid>     # Export heap dump
+jmap -finalizer_info <pid>                    # View finalizer queue
+
+# === Thread Analysis ===
+jstack <pid> > thread.txt                     # Thread stack
+jstack -l <pid>                               # Thread stack with lock info
+top -Hp <pid>                                 # Thread-level CPU usage
+
+# === GC Analysis ===
+jstat -gcutil <pid> 1000                      # Generation occupancy + GC count (refresh every second)
+jstat -gccause <pid> 1000                     # Last GC cause
+jcmd <pid> GC.heap_info                       # Heap info
+
+# === Class Analysis ===
+jmap -clstats <pid>                           # ClassLoader statistics
+jcmd <pid> VM.classloader_stats               # ClassLoader status
+jmap -permstat <pid>                          # Permanent generation statistics (JDK7)
+
+# === System Level ===
+top                                           # Process CPU/memory
+iostat -x 1                                   # Disk IO
+netstat -anp | grep <pid>                     # Network connections
+```
+
+## JVM Parameters
+
+Monitoring parameters commonly enabled during troubleshooting:
+```
+-XX:+HeapDumpOnOutOfMemoryError               # Auto dump on OOM (essential for OOM troubleshooting)
+-XX:HeapDumpPath=/var/log/dumps/              # Dump path
+-XX:ErrorFile=/var/log/hs_err_%p.log          # Fatal error log
+-Xlog:gc*:file=gc.log:time,uptime             # GC log
+-XX:+PrintFlagsFinal                          # Print all JVM parameter final values
+```
+
+**Proactive tuning parameters (heap/GC collector/JIT configuration)**: Belongs to the performance-tuning skill, see `../performance-tuning/references/jvm_params.md`.
+
+## Usage
+
+1. **Locate by symptom**: First check the "Failure Category Quick Reference" table, jump to the corresponding section.
+2. **Execute diagnostic workflow**: Each section has numbered steps; execute in order.
+3. **Check root cause table**: After diagnosis, find countermeasures in the "Common Root Causes" table.
+4. **Command details**: When command output is unclear, Read `references/diagnostic_commands.md`.
+5. **GC troubleshooting**: When investigating GC issues, Read `references/gc_tuning_guide.md` (reactive diagnostic perspective). For proactive selection and configuration, see performance-tuning.
+6. **Container troubleshooting**: For K8s/Docker container failures, Read `references/container_troubleshooting.md`.
+7. **JFR analysis**: When using JFR for troubleshooting, Read `references/jfr_analysis.md`.
+8. **Troubleshooting cases**: When an end-to-end reference is needed, Read `references/troubleshooting_cases.md`.
+9. **Do not fabricate when uncertain**: JVM behavior is governed by source code and official documentation; this skill does not replace formal documentation.
+
+## Reference Entries
+
+- **Command details**: `references/diagnostic_commands.md` (output field meanings and examples for each JVM command)
+- **GC troubleshooting guide**: `references/gc_tuning_guide.md` (GC problem troubleshooting from a reactive diagnostic perspective)
+- **Container troubleshooting**: `references/container_troubleshooting.md` (JVM failures inside K8s/Docker containers: OOM killed / PID 1 / JRE-only)
+- **JFR post-incident analysis**: `references/jfr_analysis.md` (JFR event quick reference, online streaming, JMC flame graphs)
+- **Troubleshooting cases**: `references/troubleshooting_cases.md` (4 end-to-end cases: heap leak / CPU 100% / deadlock / Metaspace leak)
+- **Proactive performance tuning**: `../performance-tuning/SKILL.md` (JVM parameter selection, GC collector selection, JIT tuning, JMH benchmarking)
+- Official documentation: `https://docs.oracle.com/en/java/javase/17/docs/specs/man/` (JDK 17 tools)
+- GC log analysis: `https://gceasy.io/`
+- Heap dump analysis: MAT (`https://eclipse.org/mat/`)
+- Project coding standards: `../coding-standard/SKILL.md`

--- a/.claude/skills/jvm-troubleshoot/references/container_troubleshooting.md
+++ b/.claude/skills/jvm-troubleshoot/references/container_troubleshooting.md
@@ -1,0 +1,347 @@
+# JVM Troubleshooting Inside Containers
+
+This file supplements SKILL.md, focusing specifically on **K8s / Docker container** JVM troubleshooting. The container environment differs significantly from physical machines; common pitfalls are organized into separate sections. Read as needed when a user reports "JVM won't start inside container / gets killed / can't see process".
+
+## Container vs Physical Machine Differences
+
+| Dimension | Physical Machine | Container |
+|---|---|---|
+| Memory visible to JVM | Physical memory | cgroup limit (JDK 17 recognizes by default) |
+| Process PID | Any | Usually PID 1 (container main process) |
+| JDK tools | Complete | May only have JRE (minimal images) |
+| JFR disk output | Local disk | emptyDir / PVC / temporary volume |
+| Kernel logs | `dmesg` accessible | Requires host permissions to see OOM killer |
+| ulimit | Default lenient | Often tightened inside containers |
+
+## Failure Category Quick Reference (Container-Specific)
+
+| Symptom | Jump to |
+|---|---|
+| Container OOM killed (exit 137) | [Container OOM Killed Troubleshooting](#container-oom-killed-troubleshooting) |
+| `jps` cannot see process inside container | [PID 1 Issue](#pid-1-issue) |
+| Container only has JRE, no JDK tools | [JRE-only Image Troubleshooting](#jre-only-image-troubleshooting) |
+| JVM startup reports "Could not reserve enough space" | [Heap Exceeds Container Memory](#heap-exceeds-container-memory) |
+| JFR / dump fails to write to disk | [Persistent Volume Configuration](#persistent-volume-configuration) |
+| Thread count limited inside container | [ulimit / Thread Count](#ulimit--thread-count) |
+
+## Container OOM Killed Troubleshooting
+
+**Symptom**: K8s Pod status `OOMKilled`, exit code 137. Docker `docker inspect` shows `OOMKilled: true`.
+
+**Root cause**: Container cgroup memory limit < JVM actual usage. **This is not a JVM OOM** -- the kernel kills the process before the JVM does.
+
+### Troubleshooting Workflow
+
+1. **Confirm it is a kernel OOM killer**:
+   ```bash
+   # K8s: Check Pod events
+   kubectl describe pod <pod> | grep -A 5 -i oom
+
+   # Docker: Check container status
+   docker inspect <container> | grep -i oom
+
+   # Host: Check kernel logs (requires host permissions)
+   dmesg | grep -i "killed process"
+   ```
+
+2. **Check if JVM is actually using that much memory**:
+   ```bash
+   # Enter container
+   kubectl exec <pod> -c <container> -- jcmd 1 VM.flags
+
+   # Check heap configuration
+   kubectl exec <pod> -c <container> -- jcmd 1 GC.heap_info
+   ```
+
+3. **Calculate JVM actual memory**:
+   ```
+   JVM total memory = Heap (Xmx)
+                   + Metaspace (MaxMetaspaceSize)
+                   + Thread stacks (Xss x thread count)
+                   + Direct memory (MaxDirectMemorySize)
+                   + CodeCache (ReservedCodeCacheSize)
+                   + GC data structures
+                   + JVM itself (approx 200-400MB)
+   ```
+
+### Common Root Causes and Countermeasures
+
+| Root Cause | Manifestation | Countermeasure |
+|---|---|---|
+| `-Xmx` exceeds container memory | JVM startup fails or gets killed during runtime | Use `-XX:MaxRAMPercentage=75.0` instead of fixed `-Xmx` |
+| `UseContainerSupport` not enabled | JDK 8u191- cannot see cgroup | Upgrade to JDK 17 (enabled by default) |
+| Direct memory not limited | Netty / NIO off-heap memory grows | Add `-XX:MaxDirectMemorySize=256m` |
+| Metaspace not limited | Dynamic proxy class bloat | Add `-XX:MaxMetaspaceSize=512m` |
+| Too many threads | Each thread uses 1M stack, 1000 threads = 1GB | Reduce `-Xss=256k` or decrease thread pool size |
+| CodeCache too large | Excessive JIT compilation | Default 240M is sufficient; adjust down in special scenarios |
+
+### Configuration Recommendations (K8s / Docker)
+
+**K8s deployment**:
+```yaml
+spec:
+  containers:
+  - name: app
+    resources:
+      requests:
+        memory: "2Gi"
+      limits:
+        memory: "4Gi"   # cgroup limit
+    env:
+    - name: JAVA_OPTS
+      value: >-
+        -XX:+UseContainerSupport
+        -XX:InitialRAMPercentage=50.0
+        -XX:MaxRAMPercentage=75.0
+        -XX:+HeapDumpOnOutOfMemoryError
+        -XX:HeapDumpPath=/var/log/dumps/
+        -Xlog:gc*:file=/var/log/gc.log:time,uptime:filecount=5,filesize=10M
+```
+
+**Recommended ratios**:
+- Heap occupies 50-75% of container memory (`MaxRAMPercentage`)
+- Leave 25-50% for Metaspace + stacks + direct memory + JVM itself
+- K8s limit should not equal request (prevent being killed on sudden spikes)
+
+## PID 1 Issue
+
+**Symptom**: `jps` cannot see the JVM process inside the container, or `jstack <pid>` fails.
+
+**Root cause**: The container's main process is PID 1. `jps` by default only lists non-PID 1 JVMs. Use `jcmd` / `jstack` with PID 1 instead.
+
+### Troubleshooting
+
+```bash
+# Wrong: jps cannot see
+kubectl exec <pod> -- jps
+
+# Correct: Use PID 1 directly
+kubectl exec <pod> -- jcmd 1 VM.flags
+kubectl exec <pod> -- jstack 1
+kubectl exec <pod> -- jstat -gcutil 1 1000
+
+# Or find the Java process first
+kubectl exec <pod> -- ps -ef | grep java
+```
+
+### JDK Tool Permission Issues Inside Containers
+
+**Symptom**: `jcmd 1 Thread.print` reports `Permission denied` or `Operation not permitted`.
+
+**Root cause**: Container user is not root; JDK tools use ptrace to attach to the process, which requires permissions.
+
+**Countermeasures**:
+- K8s: `securityContext.capabilities.add: [SYS_PTRACE]`
+- Docker: `--cap-add=SYS_PTRACE`
+- Or run container as root user (not recommended)
+
+```yaml
+spec:
+  containers:
+  - name: app
+    securityContext:
+      capabilities:
+        add: ["SYS_PTRACE"]
+```
+
+## JRE-only Image Troubleshooting
+
+**Symptom**: `jcmd` / `jstack` / `jmap` commands not found. Minimal images (e.g., `eclipse-temurin:17-jre-alpine`) only have JRE without JDK tools.
+
+### Countermeasures
+
+**Option 1: Use a sidecar container with JDK tools**:
+```yaml
+spec:
+  containers:
+  - name: app              # Main container, JRE-only
+    image: app:latest
+  - name: debug            # Sidecar with JDK
+    image: eclipse-temurin:17-jdk-alpine
+    command: ["sleep", "infinity"]
+```
+
+When troubleshooting, enter the sidecar:
+```bash
+kubectl exec <pod> -c debug -- jcmd <app-pid> ...
+# But requires shared PID namespace
+```
+
+**Option 2: Use the `jattach` tool** (lightweight, no JDK required):
+```dockerfile
+# Install jattach in the image
+RUN apk add --no-cache jattach
+```
+```bash
+jattach <pid> jcmd GC.heap_info
+jattach <pid> dump heap /tmp/heap.hprof
+```
+
+**Option 3: Install `procps` + `openjdk17-jdk` in the image** (for debugging, use cautiously in production):
+```dockerfile
+RUN apk add --no-cache openjdk17-jdk procps
+```
+
+**Option 4 (Recommended): Use JFR in production**, no JDK tools needed. JFR is embedded in the JVM; configure `StartFlightRecording` at startup and write to a log volume.
+
+## Persistent Volume Configuration
+
+**Symptom**: `-XX:HeapDumpPath=/var/log/dumps/` but no dump on OOM. JFR configured but `.jfr` files not found.
+
+**Root cause**: Path inside container is not mounted to a persistent volume; data is lost on container restart.
+
+### Configuration
+
+**K8s**:
+```yaml
+spec:
+  containers:
+  - name: app
+    volumeMounts:
+    - name: dumps
+      mountPath: /var/log/dumps
+    - name: gc-log
+      mountPath: /var/log
+  volumes:
+  - name: dumps
+    persistentVolumeClaim:
+      claimName: dumps-pvc
+  - name: gc-log
+    emptyDir: {}
+```
+
+**JVM Parameters**:
+```
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath=/var/log/dumps/           # Mounted to PVC
+-Xlog:gc*:file=/var/log/gc.log:time,uptime:filecount=10,filesize=10M
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=1h,maxsize=100M,settings=profile
+-XX:FlightRecorderOptions=stackdepth=64
+```
+
+**Notes**:
+- emptyDir is lost on container restart; only suitable for GC logs
+- dump / JFR needs persistence -> PVC or host hostPath
+- K8s `terminationGracePeriodSeconds` gives JVM time to write dump
+
+## ulimit / Thread Count
+
+**Symptom**: `OutOfMemoryError: unable to create new native thread`, but heap memory is sufficient.
+
+**Root cause**: ulimit is tightened inside the container; thread count has reached the limit.
+
+### Troubleshooting
+
+```bash
+# Enter container to check ulimit
+kubectl exec <pod> -- bash -c "ulimit -a"
+
+# Check thread count
+kubectl exec <pod> -- bash -c "ps -ef | wc -l"
+# Or
+kubectl exec <pod> -- jcmd 1 Thread.print | grep "java.lang.Thread.State" | wc -l
+```
+
+### Countermeasures
+
+| Root Cause | Countermeasure |
+|---|---|
+| ulimit -u too small | Increase via K8s `securityContext`, or Docker `--ulimit nproc=65535:65535` |
+| Thread pool leak | Check if `new Thread` is not in a pool, `submit` without `shutdown` |
+| Virtual threads (JDK 21+) | Virtual threads do not count toward native thread limit, but not available on JDK 17 |
+
+**K8s Configuration**:
+```yaml
+spec:
+  containers:
+  - name: app
+    securityContext:
+      runAsNonRoot: true
+      # ulimit adjustment needs to be done in the image or init container
+```
+
+**Adjust ulimit in the image** (Dockerfile):
+```dockerfile
+RUN echo "nproc 65535" >> /etc/security/limits.conf
+```
+
+## Heap Exceeds Container Memory
+
+**Symptom**: JVM startup fails with `Could not reserve enough space for object heap`.
+
+**Root cause**: `-Xmx` exceeds the container cgroup limit, or `MaxRAMPercentage` calculates a heap that exceeds container memory.
+
+### Troubleshooting
+
+```bash
+# Check cgroup limit
+kubectl exec <pod> -- cat /sys/fs/cgroup/memory.max       # cgroup v2
+kubectl exec <pod> -- cat /sys/fs/cgroup/memory/memory.limit_in_bytes  # cgroup v1
+
+# Check JVM startup parameters
+kubectl exec <pod> -- jcmd 1 VM.flags 2>&1 | grep -i heap
+```
+
+### Countermeasures
+
+- Use `-XX:MaxRAMPercentage=75.0` instead of fixed `-Xmx` (auto-adapts to cgroup)
+- Leave 25% for non-heap memory
+- Do not use `-XX:+UseCGroupMemoryLimitForBounds` (deprecated in JDK 11)
+
+## Network and DNS Failures
+
+Slow DNS resolution and connection timeouts inside containers are common:
+
+**Symptom**: Application starts slowly, HTTP call timeouts.
+
+**Root causes**:
+- Slow DNS resolution inside container (K8s CoreDNS pressure)
+- Connection pool not reused, new TCP connection each time
+- Container network plugin (Calico/Flannel) overhead
+
+**Troubleshooting**:
+```bash
+# Test DNS inside container
+kubectl exec <pod> -- nslookup example.com
+
+# Check connections
+kubectl exec <pod> -- netstat -anp | grep ESTABLISHED | wc -l
+```
+
+**Countermeasures**:
+- Add JVM parameter `-Dsun.net.inetaddr.ttl=30` (DNS cache for 30 seconds)
+- Use connection pool for HTTP client (OkHttp / Apache HttpClient)
+- Pre-pull images to reduce startup time
+
+## Practical Troubleshooting Command Quick Reference
+
+```bash
+# === K8s ===
+kubectl describe pod <pod> | grep -A 5 -i oom        # OOMKilled events
+kubectl logs <pod> -c <container> --previous         # Previous container logs
+kubectl top pod <pod>                                 # Real-time memory/CPU
+
+# === Inside Container ===
+jcmd 1 VM.flags                                       # JVM startup parameters (PID 1)
+jcmd 1 GC.heap_info                                   # Heap info
+jcmd 1 Thread.print                                   # Thread stack
+jcmd 1 JFR.start duration=30s filename=/tmp/r.jfr     # JFR collection
+
+# === cgroup ===
+cat /sys/fs/cgroup/memory.max                         # Memory limit (cgroup v2)
+cat /sys/fs/cgroup/memory/memory.limit_in_bytes       # cgroup v1
+cat /sys/fs/cgroup/memory.peak                        # Actual peak (cgroup v2)
+
+# === Host (requires permissions) ===
+dmesg | grep -i "killed process"                      # Kernel OOM killer logs
+```
+
+## Reference Entries
+
+- **SKILL.md**: Main entry for this skill, jump by symptom
+- **Diagnostic command details**: `diagnostic_commands.md` (jcmd/jstack/jmap output fields)
+- **GC troubleshooting guide**: `gc_tuning_guide.md` (reactive diagnostic perspective)
+- **JFR post-incident analysis**: `jfr_analysis.md` (JFR disk output + analysis inside containers)
+- Official container support documentation: `https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#containers`
+- K8s Java tuning: `https://kubernetes.io/docs/concepts/containers/`
+- jattach tool: `https://github.com/jvm-profiling-tools/jattach`

--- a/.claude/skills/jvm-troubleshoot/references/diagnostic_commands.md
+++ b/.claude/skills/jvm-troubleshoot/references/diagnostic_commands.md
@@ -1,0 +1,161 @@
+# JVM Diagnostic Command Details
+
+This file supplements the command quick reference in SKILL.md with output field meanings and common parameters for each command. Read as needed when a user asks "how to read the output of a specific command## Process Overview
+
+### `jps -lvm`
+
+Lists all JVM processes for the current user.
+
+**Output example**:
+```
+12345 com.example.Main -Xmx4g -Dspring.profiles.active=prod
+23456 sun.tools.jps.Jps -lvm
+```
+
+**Fields**: First column is PID, second column is the main class full name (`-l`), followed by JVM parameters (`-v`) and main method arguments (`-m`).
+
+### `jcmd <pid> VM.flags`
+
+View the JVM startup parameters actually in effect (including defaults).
+
+**Usage**: Confirm whether GC collector, heap size, and tuning parameters are in effect. Add `-all` to see all parameters including defaults.
+
+## Heap Analysis
+
+### `jmap -heap <pid>`
+
+View heap configuration and generation occupancy.
+
+**Key output fields**:
+```
+Heap Configuration:
+   MinHeapFreeRatio  = 40
+   MaxHeapFreeRatio  = 70
+   MaxHeapSize       = 4294967296 (4096.0MB)  # -Xmx
+   NewSize           = 1048576000 (1000.0MB)  # Young generation initial
+   MaxNewSize        = 1048576000 (1000.0MB)
+   OldSize           = 3246436896 (3096.0MB)  # Old generation
+
+Heap Usage:
+PS Young Generation
+   Eden Space:       capacity = 870318080 (830.0MB), used = 123456789
+   From Space:       capacity = 104857600 (100.0MB), used = 0
+   To   Space:       capacity = 104857600 (100.0MB), used = 0
+PS Old Generation
+   capacity = 3246436896 (3096.0MB), used = 2147483648 (2048.0MB)
+```
+
+**Assessment**: When old generation used approaches capacity, need to scale up or investigate leak.
+
+### `jmap -histo:live <pid>`
+
+Object histogram sorted by instance count. `:live` triggers a Full GC before counting, showing only live objects.
+
+**Output example**:
+```
+ num     #instances         #bytes  class name
+   1:        1200000      102400000  [B  (byte array)
+   2:         800000       25600000  java.lang.String
+   3:         100000       12000000  com.example.UserDTO
+```
+
+**Assessment**: An abnormally high instance count for a business class may indicate a leak. Note that `[B` (byte array), `[C` (char array), `[Ljava.lang.Object;` (Object array) tend to have large bytes values and are typically held by String or collections.
+
+### `jmap -dump:format=b,file=heap.hprof <pid>`
+
+Export a full heap dump (hprof format) for analysis with MAT or jvisualvm.
+
+**Key MAT operations**:
+- **Leak Suspects Report**: Automatically finds leak points
+- **Dominator Tree**: See which objects occupy the most memory
+- **GC Root paths**: See why an object was not garbage collected
+
+## Thread Analysis
+
+### `jstack <pid>`
+
+Print call stacks and lock status for all threads.
+
+**Thread state keywords**:
+- `RUNNABLE`: Currently executing or waiting for CPU
+- `BLOCKED`: Waiting for a synchronized lock
+- `WAITING`: `Object.wait()` / `LockSupport.park()` without timeout
+- `TIMED_WAITING`: `sleep(ms)` / `wait(ms)` / `parkNanos(ns)`
+
+**Deadlock detection**: jstack automatically detects synchronized deadlocks; the end of the output will show:
+```
+Found 1 deadlock.
+====================
+"Thread-1" deadlock waiting to lock <0x000000076b4f01e0>
+    held by "Thread-2"
+"Thread-2" deadlock waiting to lock <0x000000076b4f0230>
+    held by "Thread-1"
+```
+
+**Note**: ReentrantLock deadlocks are not automatically detected by jstack; you need to check if the stack is stuck in `AbstractQueuedSynchronizer.acquire`.
+
+### `top -Hp <pid>`
+
+View CPU usage per thread within a process (Linux).
+
+**Output**: TID is in decimal; needs `printf "%x\n" <tid>` to convert to hexadecimal, then use `jstack <pid> | grep <hexadecimal> -A 30` to locate the thread stack.
+
+**macOS alternative**: `Activity Monitor` -> select process -> `Sample Process`, or use `htop -p <pid>`.
+
+## GC Analysis
+
+### `jstat -gcutil <pid> <interval>`
+
+View generation occupancy percentages + GC counts; `<interval>` is the refresh interval in milliseconds.
+
+**Output fields**:
+```
+  S0     S1     E      O      M     CCS    YGC    YGCT    FGC    FGCT     GCT
+  0.00  92.15  45.30  78.50  95.20  91.40  124   3.456    8    2.891    6.347
+```
+
+| Column | Meaning | Abnormal Value |
+|---|---|---|
+| S0/S1 | Survivor 0/1 occupancy % | Always 0 or 100 may be abnormal |
+| E | Eden occupancy % | Persistently high -> frequent Young GC |
+| O | Old generation occupancy % | Continuously growing without dropping = leak |
+| M | Metaspace occupancy % | Continuously growing = class loading leak |
+| CCS | Compressed class space occupancy % | Generally follows M |
+| YGC/YGCT | Young GC count/total time | Count growing fast = object creation too fast |
+| FGC/FGCT | Full GC count/total time | Count growing fast = memory leak or heap insufficient |
+| GCT | GC total time | > 5% of runtime requires investigation |
+
+**Usage**: Observe multiple times consecutively (`jstat -gcutil <pid> 1000 10` for 10 readings), check if O and FGC keep growing.
+
+### `jstat -gccause <pid> <interval>`
+
+Same as `-gcutil` plus an additional `LGCC` column (last GC cause) and `GCC` column (current GC cause).
+
+**Common causes**:
+- `Allocation Failure`: Eden full, triggers Young GC
+- `System.gc()`: Code called `System.gc()`
+- `Metadata GC Threshold`: Metaspace insufficient
+- `GCLocker Initiated GC`: JNI critical section triggered
+
+## Class Analysis
+
+### `jmap -clstats <pid>`
+
+ClassLoader statistics showing how many classes each ClassLoader has loaded and how many bytes they occupy.
+
+**Assessment**: If the same business class is loaded by multiple ClassLoaders, or ClassLoader count keeps growing, it indicates a hot deployment/dynamic proxy leak.
+
+**Key fields**:
+- `class_loader_instances`: ClassLoader instance count
+- `total_classes`: Total loaded classes
+- `parent_loader`: Parent ClassLoader (view delegation chain)
+
+## System Level
+
+### `iostat -x 1`
+
+Disk IO details, refreshed every second. Check `%util` (disk utilization) and `await` (IO wait time). `%util` persistently > 80% or `await` > 20ms indicates a disk bottleneck.
+
+### `netstat -anp | grep <pid>`
+
+View network connections for a process. Abnormally high `ESTABLISHED` count may indicate a connection leak (connection pool not released).

--- a/.claude/skills/jvm-troubleshoot/references/gc_tuning_guide.md
+++ b/.claude/skills/jvm-troubleshoot/references/gc_tuning_guide.md
@@ -1,0 +1,167 @@
+# GC Troubleshooting Guide (Reactive Diagnostic Perspective)
+
+This file supplements the GC troubleshooting content in SKILL.md, **focusing only on the reactive diagnostic perspective** (how to troubleshoot when GC has already gone wrong). For proactive selection and configuration (selecting GC and tuning parameters before deployment), see `../../performance-tuning/references/gc_tuning.md`.
+
+**Boundary between the two files**:
+- This file: Reactive troubleshooting (frequent Full GC, GC overhead limit, long pauses) -> identification + fix
+- performance-tuning/gc_tuning.md: Proactive configuration (selecting G1/ZGC before deployment, tuning heap) -> prevention
+
+## GC Type Identification
+
+First step in troubleshooting: identify which type of GC problem is occurring.
+
+| GC | Trigger Condition | Reclaimed Region | Pause Time | Troubleshooting Focus |
+|---|---|---|---|---|
+| **Young GC / Minor GC** | Eden full | Eden + one Survivor | Short (millisecond level) | Frequent = object creation too fast or Eden too small |
+| **Mixed GC** (G1) | Old generation occupancy trigger | Young generation + some old generation regions | Medium | Occasional is normal; frequent indicates fast old generation growth |
+| **Full GC** | Old generation full / Metaspace full / `System.gc()` | Entire heap + Metaspace | Long (second level) | Frequent Full GC always has a root cause |
+
+**Troubleshooting goal**: Fewer Full GC is better. Frequent Full GC indicates a problem with the old generation or Metaspace.
+
+## Pathways for Objects Entering the Old Generation (Investigating Promotion Issues)
+
+When investigating "old generation growing too fast", check these 4 pathways:
+
+1. **Age reaches threshold**: Survives 15 Young GCs by default (`-XX:MaxTenuringThreshold`)
+2. **Large objects**: Exceeds `-XX:PretenureSizeThreshold` and goes directly to old generation
+3. **Survivor full**: When Survivor space is insufficient, surviving objects are promoted directly
+4. **Dynamic age calculation**: JVM automatically determines that too many objects of a certain age exist and promotes them early
+
+**Troubleshooting approach**: If Young GC is frequent and Full GC is also frequent, it may be premature promotion -- use `jstat -gcnew <pid> 1000` to check Survivor occupancy and see if objects are being promoted before dying in the young generation.
+
+## Troubleshooting Command Quick Reference
+
+```bash
+# View generation occupancy + GC counts (refresh every second)
+jstat -gcutil <pid> 1000
+
+# View last GC cause
+jstat -gccause <pid> 1000
+
+# View young generation details (Eden/Survivor occupancy, promotion age)
+jstat -gcnew <pid> 1000
+
+# View GC overview
+jcmd <pid> GC.heap_info
+
+# Real-time GC log (no file)
+jcmd <pid> VM.log output='file=/dev/stdout' what='gc*'
+```
+
+## Key Metrics Quick Reference (jstat -gcutil)
+
+Use `jstat -gcutil <pid> 1000` for continuous observation; focus on:
+
+| Metric | Healthy Value | Abnormal Value | Abnormal Countermeasure |
+|---|---|---|---|
+| O (old generation occupancy) | < 70% | > 80% and not dropping | Scale up or investigate leak |
+| YGC frequency | Once every few seconds | Multiple times per second | Reduce object creation |
+| FGC frequency | Once every few hours | Once per minute | Investigate leak or scale up |
+| FGCT/GCT ratio | < 20% | > 50% | High Full GC proportion, old generation issue |
+| GCT/runtime ratio | < 5% | > 10% | High overall GC overhead |
+
+**Troubleshooting focus**:
+- O continuously rising without dropping = memory leak (see SKILL.md OOM Troubleshooting)
+- High FGC frequency but O not high = possibly Metaspace full or `System.gc()` being called
+- High YGC frequency but few FGC = object creation too fast, young generation insufficient
+
+## Common Troubleshooting Scenarios
+
+### Scenario 1: Frequent Young GC
+
+**Symptom**: `jstat` shows YGC growing fast, application response fluctuates.
+
+**Troubleshooting**:
+- `jstat -gcnew <pid> 1000` to check Eden occupancy, whether it fills up in seconds
+- Check if application creates objects at high frequency (profiling allocation flame graph)
+
+**Countermeasures**:
+- Reduce object creation (caching, object pool, StringBuilder)
+- Increase young generation size (proactive tuning, see performance-tuning/gc_tuning.md)
+- Eden too small causes frequent Young GC but little reclaimed each time
+
+### Scenario 2: Frequent Full GC
+
+**Symptom**: FGC growing fast, application has long pauses.
+
+**Troubleshooting** (identify by root cause):
+- `jstat -gcutil <pid> 1000` to check if O is continuously rising without dropping
+- Old generation growing without dropping -> memory leak, get dump for analysis (see SKILL.md OOM Troubleshooting)
+- Old generation growing then dropping -> heap insufficient
+- Metaspace full -> `jmap -clstats <pid>` to check if ClassLoader count keeps growing (see SKILL.md Class Loading Troubleshooting)
+- Check if code calls `System.gc()`
+
+**Countermeasures**:
+- Memory leak -> get dump to find GC Root chain, locate leak point
+- Heap insufficient -> increase `-Xmx`
+- Metaspace full -> increase `-XX:MaxMetaspaceSize` or fix class loading leak
+- `System.gc()` being called -> add `-XX:+DisableExplicitGC`
+
+### Scenario 3: Single GC Pause Too Long
+
+**Symptom**: GC count is normal, but each FGCT is very large.
+
+**Troubleshooting**:
+- Check GC logs to confirm whether Young GC or Full GC has long pauses
+- `jcmd <pid> GC.heap_info` to check heap size and region configuration
+
+**Countermeasures**:
+- G1 Young GC pause long -> Eden too large, proactively tune `MaxGCPauseMillis` (see performance-tuning)
+- G1 Full GC pause long -> old generation fragmentation, consider switching to ZGC
+- Switch to ZGC (JDK 17+ stable, proactive configuration see performance-tuning/gc_tuning.md)
+
+### Scenario 4: Large Objects Promoted Directly to Old Generation
+
+**Symptom**: Frequent Full GC but not many objects in old generation (large objects fragmented in old generation).
+
+**Troubleshooting**:
+- `jstat -gcnew <pid> 1000` to check if Survivor is frequently full
+- Profiling to see if large arrays/large strings are being created
+
+**Countermeasures**:
+- Find large array/large string creation points, use streaming processing or sharding instead
+- Proactively tune `-XX:PretenureSizeThreshold` (see performance-tuning)
+
+### Scenario 5: GC Overhead Limit Exceeded
+
+**Symptom**: `OutOfMemoryError: GC overhead limit exceeded`.
+
+**Troubleshooting**: This is a safety mechanism when GC spends too much time reclaiming too little memory. Usually a memory leak or heap too small.
+
+**Countermeasures**:
+- First get a dump (if `-XX:+HeapDumpOnOutOfMemoryError` was enabled, dump is available)
+- MAT analysis to find leak point
+- Not a leak -> heap too small, increase `-Xmx`
+- Temporarily disable this check: `-XX:-UseGCOverheadLimit` (symptomatic, not recommended)
+
+## GC Log Analysis
+
+### JDK 17 Log Format
+
+JDK 17 unified logging syntax (`-Xlog:gc*`), log example:
+```
+[2023-12-01T10:00:00.000+0800] GC(0) Pause Young (Normal) (G1 Evacuation Pause)
+[2023-12-01T10:00:00.050+0800] GC(0) 23M->10M(64M)(50.000ms) ...
+```
+
+**Key fields**:
+- `GC(N)`: Nth GC
+- `Pause Young / Pause Full`: GC type
+- `23M->10M(64M)`: Heap before and after occupancy (total size)
+- `(50.000ms)`: Pause time
+
+### Analysis Tools
+
+- **GCViewer** (open source): `https://github.com/chewiebug/GCViewer`
+- **gceasy.io** (online): Upload GC log for automatic analysis
+- **JFR**: `jdk.GarbageCollection` event (see performance-tuning/jmh_profiling.md)
+
+## Reference Entries
+
+- **SKILL.md**: Main entry for this skill, jump by symptom (OOM/CPU 100%/high-frequency GC etc.)
+- **Diagnostic command details**: `diagnostic_commands.md` (jstat/jmap/jcmd output field meanings)
+- **Troubleshooting cases**: `troubleshooting_cases.md` (4 end-to-end cases)
+- **Proactive GC configuration**: `../../performance-tuning/references/gc_tuning.md` (selecting G1/ZGC before deployment, tuning heap, production parameter configuration)
+- **JVM parameter details**: `../../performance-tuning/references/jvm_params.md` (JDK 17 default parameter table, parameter value ranges)
+- Official GC tuning: `https://docs.oracle.com/en/java/javase/17/gctuning/`
+- GC log analysis: `https://gceasy.io/`

--- a/.claude/skills/jvm-troubleshoot/references/jfr_analysis.md
+++ b/.claude/skills/jvm-troubleshoot/references/jfr_analysis.md
@@ -1,0 +1,327 @@
+# JFR Post-Incident Analysis Guide
+
+This file supplements SKILL.md, focusing specifically on **JDK Flight Recorder (JFR) post-incident analysis**. JDK 17 JFR overhead is < 1%, making it the primary tool for reactive troubleshooting, replacing the traditional jstack/jmap approach. Read as needed when a user reports a failure requiring JFR troubleshooting, or wants to use JFR events to locate root causes.
+
+## JFR vs Traditional Tools
+
+| Dimension | jstack / jmap | JFR |
+|---|---|---|
+| Overhead | Medium (each execution impacts application) | Very low (< 1%, can be always-on) |
+| Data | Single point-in-time snapshot | Continuous time-window events |
+| Online streaming | Not supported | Supported (JDK 14+) |
+| Flame graphs | Requires additional processing | Built-in |
+| Best for | One-off diagnosis | Long-running monitoring + post-incident analysis |
+| Container friendly | Requires JDK + SYS_PTRACE | Configure at startup and use |
+
+**Conclusion**: On JDK 17, prefer JFR; use jstack/jmap as supplementary tools.
+
+## JFR Event Categories
+
+JFR events by category:
+
+| Category | Representative Events | Usage |
+|---|---|---|
+| **GC** | `jdk.GarbageCollection` | Troubleshoot frequent GC / pauses |
+| **Memory** | `jdk.ObjectAllocationSample` / `jdk.GCHeapSummary` | Troubleshoot memory allocation hotspots |
+| **Locks** | `jdk.JavaMonitorWait` / `jdk.JavaMonitorEnter` | Troubleshoot lock contention / deadlocks |
+| **Threads** | `jdk.ThreadStart` / `jdk.ThreadPark` | Troubleshoot thread leaks / blocking |
+| **CPU** | `jdk.ExecutionSample` | Flame graph source data |
+| **Class loading** | `jdk.ClassLoad` / `jdk.ClassUnload` | Troubleshoot ClassLoader leaks |
+| **IO** | `jdk.FileRead` / `jdk.SocketRead` | Troubleshoot IO blocking |
+| **Exceptions** | `jdk.JavaExceptionThrow` | Troubleshoot exception storms |
+| **JVM** | `jdk.JVMInformation` / `jdk.OSInformation` | Environment |
+
+## Which Events to Check by Failure Type
+
+### Which Events to Check Before OOM
+
+Start JFR before OOM occurs, analyze post-incident:
+
+| Event | What to Check |
+|---|---|
+| `jdk.ObjectAllocationSample` | Who is allocating large numbers of objects (find hotspots) |
+| `jdk.GCHeapSummary` | Heap growth curve (when did it start growing) |
+| `jdk.GarbageCollection` | GC frequency + reclaim rate (unable to reclaim = leak) |
+| `jdk.JavaExceptionThrow` | Whether there are many OOM exception precursors |
+
+**Analysis steps**:
+1. Open `.jfr` file in JMC
+2. Check GC Heap trend -> when did it stop dropping
+3. Check Object Allocation Sample -> which class allocates the most
+4. Correlate timeline -> which business traffic segment caused it
+
+### Which Events to Check for CPU 100%
+
+| Event | What to Check |
+|---|---|
+| `jdk.ExecutionSample` | Flame graph, which method consumes the most CPU |
+| `jdk.CPULoad` | CPU load trend |
+| `jdk.ThreadCPULoad` | Which thread consumes CPU |
+
+**Analysis steps**:
+1. JMC flame graph to find the widest method
+2. Check if GC threads are consuming CPU (`GC Thread` consuming most -> actually a GC issue)
+3. Check if business thread is in an infinite loop (fixed stack)
+
+### Which Events to Check Before Deadlock
+
+| Event | What to Check |
+|---|---|
+| `jdk.JavaMonitorEnter` | Lock wait duration + which lock |
+| `jdk.JavaMonitorWait` | `wait()` wait duration |
+| `jdk.ThreadPark` | Thread park blocking |
+| `jdk.ExecutionSample` | Thread stack (see where it's stuck) |
+
+**Note**: JFR does not automatically detect deadlocks. For deadlock detection use `jcmd <pid> Thread.print`, check for `Found Java deadlock`.
+
+**JFR for deadlock precursors**:
+1. Check `JavaMonitorEnter` wait duration distribution -> P99 long wait = intense lock contention
+2. Check timeline -> when did wait spikes begin
+3. Correlate `ExecutionSample` -> what method are threads waiting for a lock in
+
+### Which Events to Check for High-Frequency GC
+
+| Event | What to Check |
+|---|---|
+| `jdk.GarbageCollection` | GC count + duration + cause |
+| `jdk.GCHeapSummary` | Heap before/after occupancy + pause time |
+| `jdk.G1HeapRegionInformation` (G1) | Region occupancy |
+| `jdk.ObjectAllocationSample` | Allocation hotspots |
+
+**Analysis steps**:
+1. Check GC frequency + cause (`Allocation Rate` / `System.gc()` / `Metaspace`)
+2. Check Young GC vs Full GC ratio
+3. Check if old generation drops after GC (not dropping = leak)
+4. Correlate allocation sampling -> find allocation hotspots
+
+### Which Events to Check for Class Loading Leak
+
+| Event | What to Check |
+|---|---|
+| `jdk.ClassLoad` | Number of loaded classes + ClassLoader |
+| `jdk.ClassLoaderStatistics` | ClassLoader count + occupancy |
+
+**Analysis steps**:
+1. Check ClassLoader count trend
+2. Check which type of ClassLoader is continuously growing
+3. Correlate `ClassLoad` events to see what classes are being loaded
+
+## JFR Startup and Collection
+
+### Configure Always-On at Startup
+
+Recommended for production: enable JFR at startup so data is always available post-incident.
+
+```
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=1h,maxsize=100M,settings=profile
+-XX:FlightRecorderOptions=stackdepth=64
+```
+
+**Parameter explanation**:
+- `maxage=1h`: Rolling, 1 hour of data
+- `maxsize=100M`: File size limit
+- `settings=profile`: High sampling rate (vs `default` which uses fewer resources)
+- `stackdepth=64`: Stack depth (default 64, increase to 128 for complex applications)
+
+### Temporary 30-Second Collection
+
+Commonly used for reactive troubleshooting:
+
+```bash
+# Start 30-second collection
+jcmd <pid> JFR.start duration=30s filename=/tmp/recording.jfr
+
+# Inside container (PID 1)
+jcmd 1 JFR.start duration=30s filename=/tmp/recording.jfr
+```
+
+### Continuous Background Collection
+
+```bash
+# Start in background, run until stopped
+jcmd <pid> JFR.start filename=/tmp/cont.jfr maxage=1h maxsize=100M settings=profile
+
+# Check running recordings
+jcmd <pid> JFR.check
+
+# Stop and dump to file
+jcmd <pid> JFR.stop name=1 filename=/tmp/final.jfr
+```
+
+### Online Streaming (JDK 14+)
+
+No disk output required; consume JFR events within the application:
+
+```java
+import jdk.jfr.consumer.EventStream;
+
+try (EventStream stream = EventStream.openRepository()) {
+    // Real-time GC monitoring
+    stream.onEvent("jdk.GarbageCollection", e -> {
+        System.out.println("GC: " + e.getDuration("duration") + "ms");
+        if (e.getDuration("duration").toMillis() > 100) {
+            alertService.notify("Long GC detected!");
+        }
+    });
+
+    // Real-time lock wait monitoring
+    stream.onEvent("jdk.JavaMonitorEnter", e -> {
+        if (e.getDuration("duration").toMillis() > 50) {
+            log.warn("Long lock wait: " + e.getDuration("duration"));
+        }
+    });
+
+    stream.startAsync();
+    Thread.sleep(Long.MAX_VALUE);
+}
+```
+
+**Use cases**:
+- Embedded real-time monitoring and alerting in application
+- APM vendor integration
+- No dependency on external tools
+
+## JMC (JDK Mission Control) Analysis
+
+Official GUI tool for viewing JFR files.
+
+### Installation
+
+Download: `https://github.com/openjdk/jmc`
+
+### Main Views
+
+1. **Overview**: CPU/memory/GC/threads summary
+2. **GC Configuration / Pauses**: GC frequency, pause time distribution
+3. **Memory**: Heap occupancy trend, allocation hotspots
+4. **Threads**: Thread state distribution, lock waits
+5. **Code**: Method CPU sampling
+6. **I/O**: File / network IO
+7. **System**: JVM parameters, environment
+
+### JMC Flame Graphs
+
+JDK 14+ JMC supports flame graphs:
+1. Open `.jfr` file
+2. Select "Method Profile" / "Memory" view
+3. Click the flame graph button
+
+**Reading the graph**:
+- X-axis: Call stack expanded
+- Y-axis: Stack depth
+- Width: CPU/memory time proportion
+- Find the widest "flat top" -> optimization target
+
+## Command-Line JFR Analysis
+
+You can view JFR content without installing JMC:
+
+```bash
+# View all events (default first 10)
+jfr print recording.jfr
+
+# View specific events
+jfr print --events jdk.GarbageCollection recording.jfr
+
+# View specific events + JSON format
+jfr print --events jdk.JavaMonitorEnter --json recording.jfr
+
+# View summary statistics
+jfr summary recording.jfr
+
+# By category
+jfr print --categories "GC" recording.jfr
+```
+
+## JFR vs async-profiler
+
+| Dimension | JFR | async-profiler |
+|---|---|---|
+| Source | Oracle / OpenJDK official | Community open source |
+| Integration | Built into JVM | External agent |
+| Flame graphs | Built-in via JMC / `jfr print` | Directly generates HTML |
+| Event types | Many (GC/locks/IO/class loading...) | Few (CPU/Alloc/Lock) |
+| Online streaming | Supported (JDK 14+) | Not supported |
+| Production always-on | Recommended | Possible |
+| Ease of use | GUI (JMC) + CLI | CLI + flame graphs |
+
+**Choose**:
+- Global troubleshooting, long-running monitoring -> JFR
+- Quick flame graphs, find CPU/Alloc hotspots -> async-profiler
+- Production environment -> JFR always-on at startup + async-profiler for temporary sampling
+
+## Practical Analysis Workflows
+
+### Workflow 1: OOM Post-Incident Analysis
+
+1. **Enable JFR at startup**: `-XX:StartFlightRecording=...`
+2. **OOM triggers**: JVM does not exit (`HeapDumpOnOutOfMemoryError` gets dump)
+3. **Post-incident JFR review**:
+   - `jfr print --events jdk.GCHeapSummary recording.jfr` to see heap growth curve
+   - `jfr print --events jdk.ObjectAllocationSample recording.jfr` to see allocation hotspots
+   - Open in JMC to correlate timeline
+4. **Get dump and analyze with MAT**: Find GC Root chain to locate leak point
+5. **Combine JFR + dump**: Dump shows leak point, JFR shows when the leak started
+
+### Workflow 2: CPU 100% Troubleshooting
+
+1. **Start 30-second JFR**: `jcmd <pid> JFR.start duration=30s filename=/tmp/cpu.jfr`
+2. **JMC flame graph**: Find the widest method
+3. **Check if GC is consuming CPU**: `jfr print --events jdk.GarbageCollection recording.jfr`
+4. **Check thread CPU distribution**: `jdk.ThreadCPULoad` event
+5. **Combine with jstack**: `jcmd <pid> Thread.print` to see infinite loop stack
+
+### Workflow 3: Deadlock / Lock Contention Troubleshooting
+
+1. **Start 30-second JFR**
+2. **Check lock waits**: `jfr print --events jdk.JavaMonitorEnter recording.jfr`
+3. **Sort by wait duration**: Find the longest lock waits
+4. **Correlate thread stacks**: `jdk.ExecutionSample` to see what method threads are waiting for a lock in
+5. **Combine with jstack**: `jcmd <pid> Thread.print` to check for `Found Java deadlock`
+
+### Workflow 4: High-Frequency GC Troubleshooting
+
+1. **Start 30-second JFR**
+2. **Check GC events**: `jfr print --events jdk.GarbageCollection recording.jfr`
+3. **Check cause field**: Is it `Allocation Rate` or `System.gc()` or `Metaspace`
+4. **Check heap before/after occupancy**: `jdk.GCHeapSummary` to see if old generation drops
+5. **Check allocation hotspots**: `jdk.ObjectAllocationSample` to find who is allocating
+6. **Decision**:
+   - Old generation not dropping -> memory leak, get dump
+   - Allocation too fast -> optimize code to reduce allocation
+   - `System.gc()` -> add `-XX:+DisableExplicitGC`
+
+## JFR Configuration Templates
+
+### Temporary Troubleshooting (30 seconds)
+
+```
+-XX:StartFlightRecording=duration=30s,filename=/tmp/r.jfr,settings=profile
+```
+
+### Production Always-On
+
+```
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=1h,maxsize=100M,settings=profile,disk=true
+-XX:FlightRecorderOptions=stackdepth=64
+```
+
+### Low-Overhead Monitoring
+
+```
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=24h,maxsize=500M,settings=default
+-XX:FlightRecorderOptions=stackdepth=32
+```
+
+`settings=default` has lower sampling rate than `profile`, with less overhead, suitable for long-term monitoring.
+
+## Reference Entries
+
+- **SKILL.md**: Main entry for this skill, jump by symptom
+- **Diagnostic command details**: `diagnostic_commands.md` (jcmd/jstack/jmap output fields)
+- **GC troubleshooting**: `gc_tuning_guide.md` (reactive diagnostic perspective)
+- **Container troubleshooting**: `container_troubleshooting.md` (JFR disk output configuration inside containers)
+- **Proactive JMH + JFR**: `../../performance-tuning/references/jmh_profiling.md` (JMH benchmarking + JFR production always-on)
+- Official JFR documentation: `https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#starting-a-recording-on-a-running-java-application`
+- JMC download: `https://github.com/openjdk/jmc`
+- JFR online streaming: `https://docs.oracle.com/en/java/javase/17/docs/api/jdk.jfr/jdk/jfr/consumer/EventStream.html`

--- a/.claude/skills/jvm-troubleshoot/references/troubleshooting_cases.md
+++ b/.claude/skills/jvm-troubleshoot/references/troubleshooting_cases.md
@@ -1,0 +1,284 @@
+# Real Troubleshooting Cases
+
+This file supplements the failure troubleshooting in SKILL.md with 4 end-to-end cases, each containing "symptom -> diagnosis -> root cause -> fix". Read as needed when a user asks "give me a troubleshooting case" or "how to locate this type of failure".
+
+## Case 1: Heap Memory Leak (Static Map Continuously Growing)
+
+### Symptom
+
+Application becomes slow after running for 3 days, eventually reports `OutOfMemoryError: Java heap space` and restarts. After restart it recovers, but OOMs again after 3 days.
+
+### Diagnosis
+
+**1. Get dump** (application had `-XX:+HeapDumpOnOutOfMemoryError` enabled):
+```bash
+ls -lh /var/log/dumps/  # Find java_pid12345.hprof
+```
+
+**2. MAT analysis**:
+- Open Leak Suspects Report -> report shows `java.util.HashMap` occupying 1.8GB (45% of heap)
+- Check Dominator Tree -> find the largest HashMap, its GC Root is the `static` field of `com.example.cache.UserCache`
+
+**3. Confirm growth** (observe after restart):
+```bash
+jmap -histo:live <pid> | grep -i hashmap | head
+# Check again after 1 day, HashMap instance count and bytes keep growing
+```
+
+### Root Cause
+
+`UserCache` is a static HashMap; business code `put`s into it but never `remove`s; the cache has no eviction policy:
+```java
+public class UserCache {
+    private static final Map<String, User> CACHE = new HashMap<>();  // Never evicts
+    public static void put(String id, User u) { CACHE.put(id, u); }  // Only put, no remove
+}
+```
+
+### Fix
+
+**Temporary stopgap**: Restart, or add a cache limit:
+```java
+private static final Map<String, User> CACHE =
+    new LinkedHashMap<String, User>(1000, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, User> eldest) {
+            return size() > 10000;  // Limit of 10,000
+        }
+    };
+```
+
+**Root fix**: Replace hand-written cache with Caffeine / Guava Cache, configure TTL and maximum size:
+```java
+private static final Cache<String, User> CACHE = Caffeine.newBuilder()
+    .maximumSize(10_000)
+    .expireAfterWrite(1, TimeUnit.HOURS)
+    .build();
+```
+
+---
+
+## Case 2: CPU 100% (Regex Catastrophic Backtracking)
+
+### Symptom
+
+Endpoint `/api/validate` suddenly hits CPU 100%, response times out. Other endpoints are normal. After restart it temporarily recovers, but hitting that endpoint again causes 100% CPU.
+
+### Diagnosis
+
+**1. Find process**:
+```bash
+top  # PID 12345 using 99% CPU
+```
+
+**2. Find thread**:
+```bash
+top -Hp 12345
+# TID 12350 using 95% CPU
+printf "%x\n" 12350  # Output: 305e
+```
+
+**3. Check thread stack**:
+```bash
+jstack 12345 | grep 305e -A 30
+```
+
+Output:
+```
+"http-nio-8080-exec-5" #25 daemon prio=5
+   at java.util.regex.Pattern$Curly.match0(Pattern.java:4274)
+   at java.util.regex.Pattern$GroupHead.match(Pattern.java:4660)
+   at java.util.regex.Pattern$Branch.match(Pattern.java:4604)
+   ...
+   at java.util.regex.Matcher.matches(Matcher.java:249696)
+   at com.example.Validator.validate(Validator.java:25)
+```
+
+**4. Check regex**:
+```java
+// Validator.java:25
+String EMAIL_REGEX = "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$";
+// Input "aaaaaa...aaaaaa@bbb" (very long prefix) triggers catastrophic backtracking
+```
+
+### Root Cause
+
+A regex like `([a-zA-Z0-9_\-\.]+)+` with nested quantifiers (`(...+)+`) causes catastrophic backtracking. When given a very long input string, the regex engine tries all possible combinations, resulting in exponential time complexity.
+
+### Fix
+
+**Temporary stopgap**: Limit input length:
+```java
+if (input.length() > 100) throw new IllegalArgumentException("input too long");
+```
+
+**Root fix**: Simplify the regex, remove nested quantifiers:
+```java
+// Use atomic groups (not supported in JDK, use alternative) or simplify
+String EMAIL_REGEX = "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z]{2,}$";
+// Or use pre-compiled + timeout protection
+Pattern EMAIL = Pattern.compile("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z]{2,}$");
+```
+
+**Additional**: Use RE2J (linear-time regex library) instead of `java.util.regex` to completely avoid catastrophic backtracking.
+
+---
+
+## Case 3: Thread Deadlock (Inconsistent Nested synchronized Lock Ordering)
+
+### Symptom
+
+All application requests time out, but CPU usage is 0%. `/health` endpoint also times out. Appears as if the application is frozen.
+
+### Diagnosis
+
+**1. Check thread state distribution**:
+```bash
+jstack <pid> > thread.txt
+grep "java.lang.Thread.State" thread.txt | sort | uniq -c
+```
+
+Output:
+```
+  120 BLOCKED
+   30 WAITING
+    5 RUNNABLE
+```
+
+Many BLOCKED threads indicate lock contention.
+
+**2. Find deadlock**:
+```bash
+grep -A 20 "Found Java deadlock" thread.txt
+```
+
+Output:
+```
+Found 1 deadlock.
+====================
+"transfer-thread-1" deadlock waiting to lock <0x000000076b4f01e0>
+    at com.example.AccountService.transfer(AccountService.java:50)
+    - waiting to lock <0x000000076b4f01e0>
+    - locked <0x000000076b4f0230>
+"transfer-thread-2" deadlock waiting to lock <0x000000076b4f0230>
+    at com.example.AccountService.transfer(AccountService.java:50)
+    - waiting to lock <0x000000076b4f0230>
+    - locked <0x000000076b4f01e0>
+```
+
+**3. Check code**:
+```java
+public void transfer(Account from, Account to, BigDecimal amount) {
+    synchronized (from) {        // Lock from first
+        synchronized (to) {       // Then lock to
+            // Transfer
+        }
+    }
+}
+// Thread 1: transfer(A, B) -> locks A, waits for B
+// Thread 2: transfer(B, A) -> locks B, waits for A
+```
+
+### Root Cause
+
+Nested `synchronized` with inconsistent lock ordering. Thread 1 locks A->B, Thread 2 locks B->A, each waiting for the other.
+
+### Fix
+
+**Root fix**: Unify lock ordering (sort by hashCode or id):
+```java
+public void transfer(Account a, Account b, BigDecimal amount) {
+    // Sort by id, guarantee always lock the one with smaller id first
+    Account first = a.getId() < b.getId() ? a : b;
+    Account second = a.getId() < b.getId() ? b : a;
+    synchronized (first) {
+        synchronized (second) {
+            // Transfer
+        }
+    }
+}
+```
+
+**Alternative**: Use `ReentrantLock.tryLock(timeout)`:
+```java
+if (fromLock.tryLock(1, TimeUnit.SECONDS) && toLock.tryLock(1, TimeUnit.SECONDS)) {
+    try { /* Transfer */ } finally { toLock.unlock(); fromLock.unlock(); }
+}
+```
+
+---
+
+## Case 4: Metaspace Leak (CGLIB Dynamic Proxy)
+
+### Symptom
+
+Application has Full GC every few hours, eventually reports `OutOfMemoryError: Metaspace`. Recovers after restart, but the cycle repeats.
+
+### Diagnosis
+
+**1. Confirm Metaspace growth**:
+```bash
+jstat -gccause <pid> 1000
+# M column keeps growing, does not drop after Full GC
+# GCC column shows "Metadata GC Threshold"
+```
+
+**2. Check ClassLoader**:
+```bash
+jmap -clstats <pid>
+# Same business class loaded by dozens of different ClassLoaders
+# ClassLoader count keeps growing
+```
+
+**3. Find the source**:
+
+Check where the code uses CGLIB or ByteBuddy to generate proxy classes:
+```java
+// Generates a new proxy class on every call, no caching
+public Object createProxy(Object target) {
+    Enhancer enhancer = new Enhancer();
+    enhancer.setSuperclass(target.getClass());
+    enhancer.setCallback(new MyInterceptor());
+    return enhancer.create();  // Generates a new Class each time!
+}
+```
+
+### Root Cause
+
+CGLIB `Enhancer.create()` generates a new Class object on every call, stored in Metaspace. Without caching, frequent calls cause Metaspace to grow continuously.
+
+### Fix
+
+**Temporary stopgap**: Increase Metaspace:
+```
+-XX:MaxMetaspaceSize=1g  # Temporarily increase, symptomatic not root fix
+```
+
+**Root fix**: Cache proxy classes:
+```java
+private static final Map<Class<?>, Object> PROXY_CACHE = new ConcurrentHashMap<>();
+
+public Object createProxy(Object target) {
+    return PROXY_CACHE.computeIfAbsent(target.getClass(), clazz -> {
+        Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(clazz);
+        enhancer.setCallback(new MyInterceptor());
+        return enhancer.create();
+    });
+}
+```
+
+**Or**: Use JDK dynamic proxy (`Proxy.newProxyInstance`) instead of CGLIB; JDK proxy reuses the same Class for identical interfaces.
+
+## General Troubleshooting Workflow for All Cases
+
+Regardless of the failure type, the general approach is:
+
+1. **Confirm symptom**: What is the application behavior? What is the error message?
+2. **Process level**: `top` / `jps` to confirm process status
+3. **Thread level**: `top -Hp` + `jstack` to find abnormal threads
+4. **Heap/GC level**: `jstat` + `jmap` to check memory and GC
+5. **Locate code**: Find the business code line from the abnormal stack
+6. **Root cause**: Understand why this is happening (examine code logic)
+7. **Stop the bleeding**: Restart / adjust parameters / temporary limits
+8. **Root fix**: Change code / add caching / add limits / change implementation

--- a/.claude/skills/performance-tuning/SKILL.md
+++ b/.claude/skills/performance-tuning/SKILL.md
@@ -1,0 +1,407 @@
+---
+name: performance-tuning
+description: Java performance tuning guide (JDK 17 baseline). Proactively apply when users are doing performance optimization, writing high-performance code, selecting JVM parameters, tuning GC collectors, running JMH benchmarks, using Profiling tools, optimizing collections/Stream/locks/reflection, tuning JIT/inlining, or optimizing AI agent frameworks (LLM calls, JSON serialization, reflection-based dynamic invocation, prompt concatenation). Covers: JVM parameter tuning (heap/stack/GC collector selection), code-level performance (collection selection, Stream performance, reflection optimization, escape analysis, lock optimization, Records, sealed class, Vector API), compilation optimization (JIT, inlining, tiered compilation, CDS/GraalVM), performance testing (JMH benchmarks, JFR, async-profiler, Arthas), AI agent framework-specific optimization (OkHttp connection pool, Jackson streaming parsing, MethodHandle tool invocation, prompt StringBuilder, CompletableFuture orchestration). Related keywords: performance tuning, JMH, benchmark, JIT, inlining, Profiling, escape analysis, stack allocation, lock optimization, lock coarsening, lock elision, TLAB, Stream performance, collection selection, reflection optimization, Records, sealed, Vector API, --add-opens, JFR, flame graph, ZGC, G1, GraalVM, LLM call, OkHttp, connection pool, Jackson, JSON serialization, prompt concatenation, MethodHandle, LambdaMetafactory, agent framework. Complements jvm-troubleshoot -- jvm-troubleshoot is "how to investigate when problems occur" (reactive), while this is "how to write fast code" (proactive). Not applicable to: coding standard issues (use coding-standard), JVM production incident troubleshooting (use jvm-troubleshoot), refactoring process governance (use refactor-guide).
+---
+
+# Java Performance Tuning Guide (JDK 17 baseline)
+
+This skill uses **JDK 17 as the baseline**, organized by "optimization layer -> decision table -> optimization points", covering 4 layers of performance optimization. All optimizations should follow the principle of **measure first, then tune** -- never guess based on experience.
+
+**Boundary with jvm-troubleshoot**:
+- jvm-troubleshoot: Production issues already occurred (OOM/CPU 100%/deadlock) -> follow "symptom -> diagnosis -> fix" to investigate
+- This skill: Code/configuration hasn't broken yet, but you want it faster -> follow "layer -> selection -> optimization" to prevent issues
+
+## Optimization Layer Quick Reference
+
+| Optimization Target | Jump To | Detailed Documentation |
+|---|---|---|
+| Select JVM parameters, tune GC collector | [JVM Parameter Tuning](#jvm-parameter-tuning) | `references/jvm_params.md`, `references/gc_tuning.md` |
+| Select collections / optimize Stream / optimize locks / optimize reflection when writing code | [Code-Level Performance](#code-level-performance) | `references/code_level_optimization.md` |
+| Understand JIT inlining, tiered compilation, warmup | [Compilation Optimization](#compilation-optimization) | `references/jit_compiler.md` |
+| Run benchmarks, use Profiling to locate bottlenecks | [Performance Testing & Profiling](#performance-testing--profiling) | `references/jmh_profiling.md` |
+| Reference complete tuning workflow cases | [Real-World Cases](#real-world-cases) | `references/tuning_cases.md` |
+| AI agent framework-specific optimization (LLM calls / JSON / reflection / prompt) | [AI Agent Framework Optimization](#ai-agent-framework-optimization) | `references/ai_agent_optimization.md` |
+| Not sure which layer is the bottleneck | Start with [Performance Optimization Decision Flow](#performance-optimization-decision-flow) | - |
+
+## Performance Optimization Decision Flow
+
+**Always follow this order, never skip steps**:
+
+1. **Measure baseline first**: Use JMH or Profiling to get current performance numbers (throughput/latency/P99). No data, no optimization.
+2. **Locate bottleneck layer**: Use Profiling (async-profiler / JFR) to see which of CPU/memory/locks/IO is the hotspot.
+3. **Optimize from the top layer down**: Business algorithm > Data structure > Code style > JVM parameters > Hardware
+   - Changing algorithm from O(n^2) to O(n log n) yields far more benefit than tuning JVM parameters.
+4. **Change only one variable at a time**: After each change, re-measure and compare before/after data.
+5. **Don't stop until the target is met**: Performance optimization is an iterative process, not a one-shot deal.
+
+**Anti-patterns**:
+- Adjusting `-Xmx` and GC parameters without measuring -> mostly no benefit
+- Deploying code changes without running JMH -> no idea if it got faster or slower
+- Assuming Stream/parallelStream is always faster -> many scenarios are slower than for loops
+- Forcing reflection in JDK 17 without `--add-opens` -> `InaccessibleObjectException`
+
+## JVM Parameter Tuning
+
+### Heap Size Decision
+
+| Scenario | -Xms / -Xmx | Reason |
+|---|---|---|
+| Microservice / Container | `-Xms = -Xmx`, 50-75% of container memory | Avoid heap dynamic expansion pauses |
+| Batch processing | `-Xms < -Xmx` | Gradual growth, save memory |
+| High throughput low latency | `-Xms = -Xmx`, heap not too large | Large heap = long GC time |
+| Large cache application | Large heap + ZGC | Reduce Full GC; ZGC pause does not grow with heap |
+
+**Rules of thumb**:
+- Bigger heap is not always better. 32GB+ disables compressed oops (`-XX:+UseCompressedOops`), object references become 8 bytes, actually consuming more memory.
+- Inside containers: `-XX:+UseContainerSupport` (enabled by default in JDK 17), lets JVM recognize container memory limits.
+- Using percentages is more convenient: `-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=75.0`
+
+### Stack Size Tuning
+
+| Scenario | -Xss | Reason |
+|---|---|---|
+| Default | 1M (JDK 17 Linux x64) | Sufficient for most applications |
+| Deep recursion | 2M-4M | Prevent StackOverflowError |
+| Many threads | 256K | Save thread memory (each thread gets its own stack) |
+
+### GC Collector Selection
+
+JDK 17 stable collectors:
+
+| Scenario | Heap Size | Pause Requirement | Recommended Collector | Key Parameters |
+|---|---|---|---|---|
+| Microservice / Default | < 4GB | Within 200ms | G1 (JDK 17 default) | `-XX:MaxGCPauseMillis=200` |
+| Medium application | 4-8GB | Within 200ms | G1 | `-XX:MaxGCPauseMillis=200 -XX:G1HeapRegionSize=8m` |
+| Large low-latency | 8-32GB | Within 50ms | ZGC | `-XX:+UseZGC -XX:ZAllocationSpikeTolerance=2` |
+| Very large heap | 32GB-16TB | Sub-millisecond | ZGC | Same as above; increase `-XX:ConcGCThreads` if needed |
+| High throughput batch | Any | No pause requirement | Parallel | `-XX:+UseParallelGC -XX:ParallelGCThreads=N` |
+| Low pause + concurrent marking | Medium | Within 100ms | Shenandoah (OpenJDK) | `-XX:+UseShenandoahGC` |
+
+**JDK 17 ZGC key point**: Non-generational version (generational ZGC is stable only in JDK 21+). Heap > 32GB + throughput-sensitive -> upgrade to JDK 21.
+
+**Selection decision**:
+1. JDK 17 + heap >= 8GB + low latency -> prefer ZGC
+2. JDK 17 + heap < 8GB -> G1 (default)
+3. Throughput first (offline computation) -> Parallel
+4. Heap > 32GB + throughput-sensitive -> upgrade to JDK 21 generational ZGC
+
+**Do not**:
+- Use ZGC with heap < 4GB -> no benefit
+- Switch collectors without measuring -> might be slower
+- Set `-XX:MaxGCPauseMillis=1` -> mostly unachievable, causes frequent GC instead
+
+See `references/gc_tuning.md` for more GC tuning details.
+
+### Key JVM Parameter Quick Reference
+
+**Monitoring (commonly enabled in JDK 17 production)**:
+```
+-Xlog:gc*:file=gc.log:time,uptime:filecount=10,filesize=10M   # GC log
+-XX:+HeapDumpOnOutOfMemoryError                                # Auto dump on OOM
+-XX:HeapDumpPath=/var/log/dumps/                              # dump path
+-XX:ErrorFile=/var/log/hs_err_%p.log                           # Fatal error log
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=1h,maxsize=100M,settings=profile  # JFR always on
+```
+
+**Common tuning parameters**:
+```
+-Xms4g -Xmx4g                              # Initial/max heap, equal to avoid expansion
+-XX:MetaspaceSize=256m                     # Initial Metaspace
+-XX:MaxMetaspaceSize=512m                  # Metaspace upper limit
+-XX:+DisableExplicitGC                     # Disable System.gc()
+-XX:+AlwaysPreTouch                        # Pre-touch all pages at startup
+-XX:ParallelGCThreads=N                    # GC thread count, default CPU cores * 5/8
+-XX:ConcGCThreads=N                        # Concurrent GC thread count, default ParallelGCThreads * 1/4
+```
+
+**JIT-related**:
+```
+-XX:+TieredCompilation                     # Tiered compilation (enabled by default in JDK 17)
+-XX:ReservedCodeCacheSize=256m             # JIT code cache; too small triggers deoptimization
+```
+
+**Module system (JDK 17 must-know)**:
+```
+--add-opens java.base/java.lang=ALL-UNNAMED            # Reflective access to String internals
+--add-opens java.base/java.util=ALL-UNNAMED            # Reflective access to collection internals
+--add-opens java.base/java.nio=ALL-UNNAMED             # Netty reflective access to NIO
+```
+
+See `references/jvm_params.md` for the complete JVM parameter list.
+
+## Code-Level Performance
+
+### Collection Selection
+
+Select collections based on access patterns; don't default to `ArrayList`/`HashMap`:
+
+| Scenario | Choose | Don't Choose |
+|---|---|---|
+| Frequent random reads, few writes | `ArrayList` / `CopyOnWriteArrayList` (many reads, very few writes) | `LinkedList` |
+| Frequent head insert/delete | `ArrayDeque` / `LinkedList` | `ArrayList` (head is O(n)) |
+| Frequent tail insert | `ArrayList` (amortized O(1)) | `LinkedList` (high node overhead) |
+| High concurrent reads + occasional writes | `ConcurrentHashMap` | `HashMap` + `synchronized` |
+| High concurrent reads + very few writes | `CopyOnWriteArrayList` | `Vector` |
+| Key is enum | `EnumMap` (array-based, fastest) | `HashMap` |
+| Enum set | `EnumSet` (bit vector) | `HashSet` |
+| LRU cache | `LinkedHashMap` + `removeEldestEntry` | `HashMap` + hand-written |
+
+**HashMap with known size, adjust capacity**: `new HashMap<>(expectedSize / 0.75 + 1)` to avoid resizing.
+
+See `references/code_level_optimization.md` for more collection optimization details.
+
+### Stream Performance
+
+Stream is **not a performance optimization tool**; it is a readability tool. Using it incorrectly can be slower:
+
+| Scenario | Stream | for Loop |
+|---|---|---|
+| Simple iteration | Slower (boxing/iterator overhead) | Faster |
+| Complex chained filter/map/reduce | Comparable or slightly slower | Harder to write but faster |
+| Large data parallel | `parallelStream` may be faster | Single-threaded for |
+| Small collection (< 1000) | Slower | Faster |
+
+**Stream anti-patterns**:
+- `stream().collect(toList()).stream()` -- redundant boxing
+- `list.parallelStream()` on small collections -- ForkJoin splitting overhead > benefit
+- `stream.forEach(x -> sb.append(x))` -- use `collect(joining(","))`
+
+### Reflection Optimization
+
+Reflection is slow but useful. Optimization path:
+
+| Optimization Level | Approach | Benefit |
+|---|---|---|
+| 0: Cache Method/Field | `static final Method M = ...` | 10x+ |
+| 1: setAccessible(true) | Disable access checks | 2-5x |
+| 2: MethodHandle | `MethodHandles.lookup()` | Close to direct call |
+| 3: LambdaMetafactory | Convert MethodHandle to Lambda | Close to direct call |
+| 4: Bytecode generation | ByteBuddy/CGLIB | Fastest, but has generation cost |
+
+**JDK 17 module system**: Reflective access to non-exported packages requires `--add-opens`, otherwise `InaccessibleObjectException`.
+
+### Lock Optimization
+
+Finer locks are not always better. Lock optimization has 4 levels:
+
+| Level | Technique | Applicable |
+|---|---|---|
+| **Lock elision** | `-XX:+DoEscapeAnalysis` (enabled by default in JDK 17) | Local objects with no contention; JIT auto-eliminates |
+| **Lock coarsening** | JIT merges adjacent synchronized blocks | `synchronized` inside loop merged outside loop |
+| **Lock granularity** | `ConcurrentHashMap` segmentation -> red-black tree | High concurrent writes |
+| **Lock-free** | `Atomic*` / `LongAdder` / `VarHandle` | Counter/statistics scenarios |
+
+**Lock selection decision**:
+| Scenario | Choose | Don't Choose |
+|---|---|---|
+| Low contention | `synchronized` | `ReentrantLock` (higher overhead) |
+| Need timeout/interrupt | `ReentrantLock.tryLock(timeout)` | `synchronized` (not supported) |
+| Many reads, few writes | `StampedLock` (optimistic read) | `ReentrantReadWriteLock` |
+| Fair queuing | `ReentrantLock(fair=true)` | `synchronized` (unfair) |
+| Counter | `LongAdder` | `AtomicLong` (slow under high concurrency) |
+
+### JDK 17 New Features
+
+| Feature | Performance Benefit | Usage |
+|---|---|---|
+| **Records** (JDK 14+ stable) | Compiler-generated equals/hashCode/toString, no reflection | `public record Point(int x, int y) {}` |
+| **Sealed class** (JDK 17 stable) | Compile-time exhaustive matching, helps JIT devirtualization | `sealed interface Shape permits Circle, Rectangle, Triangle {}` |
+| **Vector API** (incubator) | Explicit SIMD, more stable than C2 auto-vectorization | `--add-modules jdk.incubator.vector` |
+| **Foreign Memory API** (incubator) | Off-heap memory access, replaces Unsafe | `--add-modules jdk.incubator.foreign` |
+| **Compact Strings** (JDK 9+ default) | ASCII string memory halved | Enabled by default, no configuration needed |
+| **CDS / AppCDS** | Startup acceleration 30-50% | `java -Xshare:dump` |
+| **GraalVM Native Image** | AOT compilation, millisecond startup | Preferred for CLI / function computing |
+
+**Virtual threads**: Only stable in JDK 21+, not available in JDK 17. JDK 17 alternative: use `CompletableFuture` / `Reactor`.
+
+See `references/code_level_optimization.md` for more code-level optimization details.
+
+## Compilation Optimization
+
+### JIT Tiered Compilation
+
+JDK 17 enables tiered compilation by default, with 5 tiers:
+
+| Tier | Interpreter | C1 | C2 | Description |
+|---|---|---|---|---|
+| 0 | Yes | | | Interpreted execution, collects invocation counts |
+| 1 | | Yes | | C1 compiled, no profiling |
+| 2 | | Yes | | C1 + profiling |
+| 3 | | Yes | | C1 + full profiling (most methods stop here) |
+| 4 | | | Yes | C2 compiled, aggressive optimization (inlining/escape analysis/loop unrolling) |
+
+**Warmup**:
+- Method invocation count reaches threshold (default 10000) to trigger C1 -> C2 compilation
+- Long-running applications (production services) stabilize after warmup; short-running applications (CLI/batch) may run entirely in interpreted mode
+- Short-running applications should consider GraalVM Native Image or CDS
+
+**Code cache**: `-XX:ReservedCodeCacheSize=256m` (JDK 17 default 240M); too small triggers deoptimization.
+
+See `references/jit_compiler.md` for more JIT details.
+
+### Inlining Optimization
+
+Inlining is JIT's most important optimization. **Help inlining**:
+- Don't write hot methods too large (< 35 bytecodes, `-XX:MaxInlineSize`)
+- Add `final` to classes/methods to help JIT determine non-virtual calls -> inlining
+- Use sealed class (JDK 17) to let JIT know all implementations -> monomorphic inlining
+- Don't use complex inheritance hierarchies on hot paths (virtual methods are hard to inline)
+
+**Anti-patterns**:
+- Complex inheritance hierarchies on hot paths -> virtual method polymorphism, no inlining
+- Using reflection on hot paths -> JIT has difficulty optimizing
+- Lambda capturing variables on hot paths -> creates Lambda object each time
+
+## Performance Testing & Profiling
+
+### JMH Benchmarking
+
+JMH is OpenJDK's Java benchmarking framework, the **only trustworthy** Java microbenchmark tool.
+
+**When to use JMH**: Verify if a coding pattern is faster, measure method throughput/latency, compare before/after optimization.
+
+**When not to use JMH**: Measure entire application performance (use Profiling + integration testing), measure IO-intensive scenarios (JMH is inaccurate), measure one-time initialization (not JMH's design goal).
+
+**Minimal JMH usage**:
+```java
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class CollectionBenchmark {
+
+    @Param({"100", "1000", "10000"})
+    int size;
+
+    List<Integer> list;
+
+    @Setup
+    public void setup() {
+        list = IntStream.range(0, size).boxed().collect(toList());
+    }
+
+    @Benchmark
+    public int forEachSum() {
+        int sum = 0;
+        for (int x : list) sum += x;
+        return sum;
+    }
+
+    @Benchmark
+    public int streamSum() {
+        return list.stream().mapToInt(Integer::intValue).sum();
+    }
+}
+```
+
+**JMH pitfalls**: Must use `@Fork(2)`, must have sufficient `@Warmup`, don't `new` objects inside benchmark methods, avoid dead code elimination (use `Blackhole`).
+
+**JDK 17 JMH notes**:
+- Reflective access to non-exported packages requires `--add-opens`: `@Fork(jvmArgsAppend = {"--add-opens", "java.base/java.lang=ALL-UNNAMED"})`
+- Vector API benchmark requires `--add-modules jdk.incubator.vector`
+
+See `references/jmh_profiling.md` for more JMH details.
+
+### Profiling Tools
+
+Select tools by granularity:
+
+| Tool | Granularity | Scenario | Overhead |
+|---|---|---|---|
+| **JFR** (JDK Flight Recorder) | System-level + method-level | Production long-running, view CPU/memory/IO/locks | Very low (< 1%) |
+| **async-profiler** | Method-level CPU/Alloc/Lock | Continuous sampling, flame graphs | Low (< 1%) |
+| **JProfiler / YourKit** | Full-featured GUI | Local deep tuning | Medium |
+| **VisualVM** | Overview | Local quick view | Medium |
+| **JMH** | Method-level precise | Microbenchmark | High (dedicated run) |
+| **Arthas** | Online diagnosis | Production dynamic trace | Medium |
+
+**JDK 17 JFR advantages**: Streaming API (JDK 14+) enables real-time streaming consumption of events without disk persistence. `settings=profile` provides more complete events. Commonly enabled in production: `-XX:StartFlightRecording=...`.
+
+**async-profiler flame graph**:
+```bash
+./profiler.sh -d 30 -f flame.html <pid>            # CPU
+./profiler.sh -d 30 -e alloc -f alloc.html <pid>    # Allocation
+./profiler.sh -d 30 -e lock -f lock.html <pid>      # Lock
+```
+
+### Performance Metrics System
+
+| Metric | Meaning | Optimization Target |
+|---|---|---|
+| **Throughput** (QPS/TPS) | Requests processed per second | Higher is better |
+| **Average latency** | Average request time | Lower is better (but skewed by long tail) |
+| **P99 latency** | Time for 99% of requests | Lower is better (more realistic reflection of experience) |
+| **P999 latency** | Time for 99.9% of requests | Look atch this for long-tail-sensitive scenarios |
+| **GC pause time** | STW duration | Shorter is better |
+| **GC throughput** | GC time proportion | < 5% |
+
+**Metric pitfalls**: Only looking at average latency without P99 -> long tail is hidden; only looking at throughput without latency -> high QPS may rely on request queuing; drawing conclusions from a single benchmark -> use statistically significant multiple measurements.
+
+## Real-World Cases
+
+Reference 6 end-to-end cases with complete tuning workflows:
+
+| Case | Optimization Point | Benefit |
+|---|---|---|
+| Stream to for loop | Simple iteration without Stream | 3.7-4.6x faster |
+| HashMap capacity + LongAdder | High-concurrency counting + map capacity tuning | 5x+ concurrent throughput |
+| Reflection to MethodHandle | Reflection must cache + MethodHandle | 27x faster |
+| Container microservice tuning | Container heap ratio + JFR + warmup | P99 300ms -> 85ms |
+| Escape analysis invalidation scenario | Simple string concatenation is better optimized by compiler | Allocation hotspot disappears |
+| ZGC switch (large heap) | G1 -> ZGC | Pause 300ms -> < 5ms |
+
+See `references/tuning_cases.md` for detailed cases.
+
+## AI Agent Framework Optimization
+
+agent-core-java is an AI agent framework with specific performance bottlenecks different from general Java applications.
+
+**LLM calls account for 90%+ of time**. Code-level optimization has limited benefit, but don't let the code layer become a drag.
+
+### Optimization Layers
+
+| Layer | Optimization Point | Benefit |
+|---|---|---|
+| LLM HTTP call | OkHttp connection pool tuning, streaming response, timeout configuration, 429 retry | Save 100-300ms/request |
+| JSON serialization | ObjectMapper singleton, streaming parsing for large payloads, disable unused features | 30-50% JSON speedup |
+| Reflection / dynamic invocation | Tool Method caching, switch to MethodHandle, LambdaMetafactory | Reflection 5-27x faster |
+| Prompt concatenation | StringBuilder with estimated capacity, don't use `+` in loops | Avoid unnecessary allocations |
+| Async orchestration | Parallelize independent steps, use dedicated thread pool for LLM | Parallel 2-3x speedup |
+| Caching | LLM response cache (temperature=0), Embedding cache | Hit saves LLM call |
+
+### Agent Framework Performance Bottleneck Distribution
+
+```
+User input -> prompt concatenation -> LLM HTTP call (slowest) -> JSON parsing -> Tool invocation (reflection) -> Response concatenation
+```
+
+LLM HTTP calls account for 90%+ of time. Code-level optimization has limited benefit, but every microsecond of latency accumulates into milliseconds under high QPS.
+
+See `references/ai_agent_optimization.md` for detailed optimization (including OkHttp / Jackson / reflection / prompt / async orchestration / caching strategies + practical checklist).
+
+## Reference Entry Points
+
+- **JVM Parameter Details**: `references/jvm_params.md` (JDK 17 default parameter table, heap/stack/Metaspace/CodeCache/JIT parameter values)
+- **GC Tuning**: `references/gc_tuning.md` (proactive configuration, complements jvm-troubleshoot)
+- **Code-Level Optimization**: `references/code_level_optimization.md` (collections/Stream/reflection/locks/escape analysis + JDK 17 new features)
+- **JIT & Compilation Optimization**: `references/jit_compiler.md` (tiered compilation, inlining, Vector API, GraalVM)
+- **JMH & Profiling**: `references/jmh_profiling.md` (JMH API, pitfalls, JFR, flame graph reading)
+- **Real-World Cases**: `references/tuning_cases.md` (6 end-to-end optimization cases)
+- **AI Agent Framework Optimization**: `references/ai_agent_optimization.md` (LLM calls, JSON serialization, reflection, prompt, async, caching)
+- In-project incident troubleshooting: `../jvm-troubleshoot/SKILL.md` (reactive investigation after problems occur)
+- In-project coding standards: `../coding-standard/SKILL.md`
+- Official documentation: `https://docs.oracle.com/en/java/javase/17/docs/specs/man/`
+- JMH official: `https://openjdk.org/projects/code-tools/jmh/`
+- async-profiler: `https://github.com/async-profiler/async-profiler`
+- JFR / JDK Mission Control: `https://github.com/openjdk/jmc`
+
+## Usage
+
+1. **Start with the decision flow**: Performance optimization follows "measure -> locate -> optimize -> re-measure"; don't skip steps
+2. **Look up by layer**: JVM parameters -> Code-level -> Compilation -> Testing; use the "Optimization Layer Quick Reference" table to jump
+3. **Read details on demand**: Each section points to the corresponding references file
+4. **Does not replace jvm-troubleshoot**: For production issues (OOM/CPU 100%), use the incident troubleshooting skill
+5. **Don't guess based on experience**: All optimizations must be verified with JMH or Profiling
+6. **Don't fabricate when uncertain**: JVM/JIT behavior should be based on source code and official documentation; this skill does not replace formal documentation

--- a/.claude/skills/performance-tuning/references/ai_agent_optimization.md
+++ b/.claude/skills/performance-tuning/references/ai_agent_optimization.md
@@ -1,0 +1,459 @@
+# AI Agent Framework Performance Optimization
+
+This file supplements SKILL.md, targeting **AI agent framework** specific performance scenarios. agent-core-java uses OkHttp + Jackson + reflection-based dynamic invocation; performance bottlenecks differ from general Java applications. Read on demand when users are optimizing agent framework performance, tuning LLM calls, optimizing JSON serialization, or tuning prompt concatenation.
+
+## Agent Framework Performance Bottleneck Distribution
+
+Typical AI agent request chain:
+
+```
+User input -> prompt concatenation -> LLM HTTP call (slowest) -> JSON parsing -> Tool invocation (reflection) -> Response concatenation
+```
+
+| Stage | Typical Time | Optimization Direction |
+|---|---|---|
+| Prompt concatenation | Microsecond-level | StringBuilder / template |
+| LLM HTTP call | 500ms-30s (slowest) | Connection reuse / timeout / streaming response |
+| JSON parsing | Millisecond-level | Jackson streaming / Schema caching |
+| Reflection invocation | Microsecond-level | MethodHandle / LambdaMetafactory |
+| Response concatenation | Microsecond-level | StringBuilder / streaming |
+
+**Core conclusion**: LLM HTTP calls account for 90%+ of time. Code-level optimization has limited benefit, but don't let the code layer become a drag.
+
+## LLM HTTP Call Optimization
+
+### OkHttp Connection Pool Configuration
+
+OkHttp default connection pool: 5 idle connections, 5-minute timeout. Insufficient for agent high-frequency LLM API calls.
+
+**Default configuration issues**:
+- Default 5 connections -> frequent new TCP connections under high concurrency
+- Default 5-minute keep-alive -> closed after long idle period, rebuilt next time
+
+**Optimized configuration**:
+```java
+ConnectionPool pool = new ConnectionPool(
+    20,                       // Max idle connections
+    5,                        // keep-alive minutes
+    TimeUnit.MINUTES
+);
+
+OkHttpClient client = new OkHttpClient.Builder()
+    .connectionPool(pool)
+    .connectTimeout(10, TimeUnit.SECONDS)      // Connection timeout
+    .readTimeout(120, TimeUnit.SECONDS)        // LLM response is slow, give enough time
+    .writeTimeout(30, TimeUnit.SECONDS)
+    .callTimeout(180, TimeUnit.SECONDS)        // Overall timeout (including retries)
+    .retryOnConnectionFailure(true)            // Retry on connection failure
+    .protocols(Arrays.asList(Protocol.HTTP_1_1))  // LLM APIs mostly use HTTP/1.1
+    .build();
+```
+
+**Key parameters**:
+- `readTimeout`: LLM long output (thousands of tokens) may take 30s+, set to 120s
+- `callTimeout`: Overall including retries, set to 180s
+- `protocols`: HTTP/2 multiplexing is better, but some LLM APIs don't support it; HTTP/1.1 is compatible
+- `connectionPool`: Adjust based on concurrency level; concurrency 20 -> 20 connections
+
+### Connection Reuse Benefit
+
+| Scenario | New Connection | Reused Connection | Benefit |
+|---|---|---|---|
+| TCP handshake + TLS | 100-300ms | 0 | Save hundreds of milliseconds |
+| DNS resolution | 10-50ms | 0 | Save DNS |
+| First byte latency | Slightly higher | Slightly lower | 5-20% |
+
+**Reuse condition**: Same host + same port + same HTTP version.
+
+### Streaming Response Processing
+
+LLM streaming response (SSE / chunked) is 10x+ faster in perceived experience than one-shot response:
+
+```java
+// Streaming: first token in milliseconds, subsequent tokens returned incrementally
+Request request = new Request.Builder()
+    .url("https://api.openai.com/v1/chat/completions")
+    .post(RequestBody.create(payload, MediaType.parse("application/json")))
+    .build();
+
+try (Response response = client.newCall(request).execute()) {
+    try (BufferedSource source = response.body().source()) {
+        while (!source.exhausted()) {
+            String line = source.readUtf8Line();
+            if (line != null && line.startsWith("data: ")) {
+                // Process SSE event
+                handleSseEvent(line.substring(6));
+            }
+        }
+    }
+}
+```
+
+**Notes**:
+- Streaming `readTimeout` is per-read timeout, not overall timeout
+- Use `callTimeout` to control overall timeout
+- Don't use `response.body().string()` -- blocks until everything is read
+
+### Timeout Strategy
+
+| Timeout Type | Recommended Value | Reason |
+|---|---|---|
+| `connectTimeout` | 10s | Slow connection is usually a network issue |
+| `readTimeout` | 120s | LLM long output is slow |
+| `writeTimeout` | 30s | Request body is generally small |
+| `callTimeout` | 180s | Overall including retries |
+| `retryOnConnectionFailure` | true | Reconnect on network jitter |
+
+### Retry and Backoff
+
+LLM API rate limiting (429) is common. Exponential backoff:
+
+```java
+public Response callWithRetry(Request request, int maxRetries) throws IOException {
+    int attempt = 0;
+    while (true) {
+        try {
+            return client.newCall(request).execute();
+        } catch (IOException e) {
+            if (++attempt > maxRetries) throw e;
+            long backoff = (long) Math.pow(2, attempt) * 1000;  // 1s, 2s, 4s, ...
+            sleep(backoff);
+        }
+    }
+}
+```
+
+**Notes**:
+- On 429, check `Retry-After` header
+- Don't use OkHttp default retry (only default retry (only retries connection, not the call)
+
+## JSON Serialization Optimization
+
+Agent frameworks use JSON heavily (LLM responses, tool parameters, configuration). Jackson is mainstream, but using it incorrectly is slow.
+
+### Jackson Performance Key Points
+
+**1. Reuse ObjectMapper**
+
+```java
+// Wrong: new instance each time
+ObjectMapper mapper = new ObjectMapper();  // Heavyweight, slow initialization
+String json = mapper.writeValueAsString(obj);
+
+// Right: singleton reuse
+private static final ObjectMapper MAPPER = new ObjectMapper();
+// Or inject via Spring
+```
+
+**2. Use streaming API for large payloads**
+
+```java
+// Slow: DOM tree (read everything into memory then process)
+JsonNode root = MAPPER.readTree(json);
+String text = root.get("choices").get(0).get("message").get("content").asText();
+
+// Fast: streaming (parse while reading)
+try (JsonParser parser = MAPPER.getFactory().createParser(json)) {
+    while (parser.nextToken() != null) {
+        if ("content".equals(parser.getCurrentName())) {
+            parser.nextToken();
+            String content = parser.getText();
+            break;
+        }
+    }
+}
+```
+
+**3. Disable unused features**:
+```java
+ObjectMapper mapper = new ObjectMapper();
+mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+mapper.disable(SerializationFeature.INDENT_OUTPUT);  // Disable indentation in production
+```
+
+**4. Schema caching**:
+
+```java
+// Slow: reflection serialization each time
+mapper.writeValueAsString(obj);  // Internal reflection + type discovery
+
+// Fast: pre-generated schema
+SimpleModule module = new SimpleModule();
+module.addSerializer(MyPojo.class, new MyPojoSerializer());  // Hand-written or pre-generated
+mapper.registerModule(module);
+```
+
+### Jackson vs Gson vs JsonB
+
+| Library | Performance | Size | Notes |
+|---|---|---|---|
+| **Jackson** | Fast | Medium | Mainstream, full ecosystem |
+| **Gson** | Slow (about 30-50%) | Small | Simple and easy to use |
+| **JsonB** (Yasson) | Close to Jackson | Medium | Standard API |
+| **jsoniter** | Fastest | Small | Third-party |
+| **protobuf** | 5-10x faster than JSON | Binary | Cross-language, requires schema |
+
+**Selection**: Agent frameworks use Jackson as mainstream; for extreme performance use jsoniter or protobuf (requires LLM API support).
+
+### LLM Response JSON Parsing
+
+LLM-returned JSON is often non-standard (extra fields / field type changes / contains markdown code blocks):
+
+```java
+// Defensive parsing
+mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+
+// Strip ```json code block
+String cleaned = rawJson.replaceAll("^```json\\s*", "").replaceAll("\\s*```$", "");
+```
+
+## Reflection and Dynamic Invocation Optimization
+
+Agent frameworks have many dynamic invocations of tools/agents, creating many reflection hotspots.
+
+### Tool Invocation Reflection Optimization
+
+Agent tools typically: method name + parameter map -> reflectively call Java method.
+
+**Anti-pattern**: Reflectively look up method each time:
+```java
+public Object invokeTool(Object target, String method, Object[] args) throws Exception {
+    Method m = target.getClass().getMethod(method, ...);  // Reflective lookup each time
+    return m.invoke(target, args);
+}
+```
+
+**Optimization 1: Cache Method**:
+```java
+private static final Map<String, Method> METHOD_CACHE = new ConcurrentHashMap<>();
+
+public Object invokeTool(Object target, String method, Object[] args) throws Exception {
+    String key = target.getClass().getName() + "#" + method;
+    Method m = METHOD_CACHE.computeIfAbsent(key, k -> {
+        try {
+            Method mm = target.getClass().getMethod(method);
+            mm.setAccessible(true);
+            return mm;
+        } catch (NoSuchMethodException e) { throw new RuntimeException(e); }
+    });
+    return m.invoke(target, args);
+}
+```
+
+**Optimization 2: MethodHandle** (faster):
+```java
+private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+private static final Map<String, MethodHandle> MH_CACHE = new ConcurrentHashMap<>();
+
+public Object invokeTool(Object target, String method) throws Throwable {
+    String key = target.getClass().getName() + "#" + method;
+    MethodHandle mh = MH_CACHE.computeIfAbsent(key, k -> {
+        try {
+            return LOOKUP.findVirtual(target.getClass(), method,
+                MethodType.methodType(Object.class));
+        } catch (Exception e) { throw new RuntimeException(e); }
+    });
+    return mh.invoke(target);
+}
+```
+
+**Optimization 3: LambdaMetafactory** (fastest, close to direct call):
+```java
+// Convert MethodHandle to Function, no reflection overhead at runtime
+Function<Object, Object> fn = (Function<Object, Object>) LambdaMetafactory.metafactory(
+    LOOKUP, "apply", MethodType.methodType(Function.class),
+    MethodType.methodType(Object.class, Object.class),
+    mh, MethodType.methodType(Object.class, target.getClass())
+).getTarget().invoke();
+```
+
+### JDK 17 Module System Notes
+
+Reflective access to non-exported packages requires `--add-opens`:
+
+```
+--add-opens java.base/java.lang=ALL-UNNAMED
+--add-opens java.base/java.util=ALL-UNNAMED
+```
+
+See jvm-troubleshoot SKILL.md [Module System Troubleshooting](../../jvm-troubleshoot/SKILL.md#module-system-troubleshooting).
+
+## Prompt Concatenation Performance
+
+Prompt templates with hundreds of lines of concatenation; simple StringBuilder is sufficient, don't use complex template engines.
+
+### Template Engine Performance Comparison
+
+| Approach | Performance | Flexibility | Notes |
+|---|---|---|---|
+| `+` string concatenation | Slow (in loops) | Low | Compiler auto-optimizes in simple cases |
+| `StringBuilder` | Fast | Medium | Mainstream, sufficient |
+| `String.format` | Slow | Medium | Don't use on hot paths |
+| `MessageFormat` | Slow | Medium | Don't use |
+| `StringSubstitutor` (Apache) | Medium | High | Convenient variable substitution |
+| Mustache / Handlebars | Slow | High | Use for complex templates |
+| JTE (compiled templates) | Fastest | High | Generates bytecode at compile time |
+
+**Recommendations**:
+- Simple templates -> `StringBuilder` + variable substitution
+- Complex templates -> JTE (compile-time optimization, performance close to StringBuilder)
+
+### StringBuilder Optimization
+
+```java
+// Wrong: + inside loop
+String prompt = "";
+for (String line : lines) {
+    prompt += line + "\n";  // New StringBuilder each iteration
+}
+
+// Right: StringBuilder outside loop
+StringBuilder sb = new StringBuilder(1024);  // Estimate capacity to avoid resizing
+for (String line : lines) {
+    sb.append(line).append('\n');
+}
+String prompt = sb.toString();
+```
+
+**Estimate capacity**: Prompt length can be estimated; `new StringBuilder(expectedSize)` avoids resizing copies.
+
+## Async Orchestration Optimization
+
+Agent multi-step reasoning (e.g., ReAct) uses `CompletableFuture` orchestration:
+
+```java
+// Sequential: slow
+CompletableFuture<String> f1 = callLlm(prompt1);
+String r1 = f1.join();
+CompletableFuture<String> f2 = callLlm(r1 + prompt2);
+String r2 = f2.join();
+
+// Parallel independent steps: fast
+CompletableFuture<String> f1 = callLlm(prompt1);
+CompletableFuture<String> f2 = callLlm(prompt2);  // Independent, can be parallelized
+CompletableFuture<Void> all = CompletableFuture.allOf(f1, f2);
+all.join();
+```
+
+**Notes**:
+- LLM calls are IO; for parallel execution use a dedicated thread pool (don't use ForkJoinPool.commonPool)
+- Don't do CPU-intensive logic inside `CompletableFuture` (blocks the thread pool)
+- Streaming response + CompletableFuture combination is complex; Reactor is more suitable
+
+## Caching Strategy
+
+Cacheable items in agent frameworks:
+
+| Cache Target | Hit Rate | Benefit | Invalidation Strategy |
+|---|---|---|---|
+| LLM response (same prompt) | Medium | Huge (saves LLM call) | Prompt hash + TTL |
+| ObjectMapper | 100% (singleton) | Medium | Never invalidates |
+| Method / MethodHandle | 100% (cached) | Small | Never invalidates |
+| Embedding vector | High | Large | Content hash + TTL |
+| Tool description | High | Medium | Tool list change |
+
+**LLM response caching**:
+```java
+Cache<String, String> llmCache = Caffeine.newBuilder()
+    .maximumSize(1000)
+    .expireAfterAccess(1, TimeUnit.HOURS)
+    .build();
+
+String response = llmCache.get(promptHash, k -> callLlm(prompt));
+```
+
+**Notes**:
+- LLM responses have randomness (temperature > 0); caching is only effective for temperature=0
+- Minor prompt changes -> cache miss; prompts need to be normalized
+
+## Performance Testing (Agent Framework Specific)
+
+### LLM Call Benchmark
+
+```java
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class LlmCallBenchmark {
+
+    OkHttpClient client;
+    Request request;
+
+    @Setup
+    public void setup() {
+        client = new OkHttpClient.Builder()
+            .connectionPool(new ConnectionPool(20, 5, TimeUnit.MINUTES))
+            .build();
+        request = new Request.Builder()
+            .url("https://api.openai.com/v1/chat/completions")
+            .post(RequestBody.create("{\"model\":\"gpt-4\",\"messages\":[...]}", MediaType.parse("application/json")))
+            .build();
+    }
+
+    @Benchmark
+    public String callLlm() throws IOException {
+        try (Response r = client.newCall(request).execute()) {
+            return r.body().string();
+        }
+    }
+}
+```
+
+**Note**: LLM calls are IO; JMH single-threaded benchmarks may not represent real load. For production load testing use wrk / k6.
+
+### JSON Parsing Benchmark
+
+```java
+@Benchmark
+public String parseLlmResponse(Blackhole bh) throws IOException {
+    JsonNode root = MAPPER.readTree(LLM_RESPONSE_JSON);
+    bh.consume(root.get("choices").get(0).get("message").get("content").asText());
+    return root.toString();
+}
+```
+
+## Practical Optimization Checklist
+
+### LLM Call Layer
+- [ ] Tune OkHttp connection pool to match concurrency level
+- [ ] Set sufficient `readTimeout` (120s+)
+- [ ] Process streaming responses (fast first token)
+- [ ] Exponential backoff retry on 429 rate limiting
+- [ ] Cache LLM responses when temperature=0
+
+### JSON Serialization Layer
+- [ ] ObjectMapper singleton reuse
+- [ ] Use streaming API for large payloads
+- [ ] Disable INDENT_OUTPUT (in production)
+- [ ] Disable FAIL_ON_UNKNOWN_PROPERTIES
+
+### Reflection / Dynamic Invocation Layer
+- [ ] Cache tool Method objects
+- [ ] Switch to MethodHandle (5-10x performance)
+- [ ] Use LambdaMetafactory on critical paths
+- [ ] Add `--add-opens` for JDK 17
+
+### Prompt / Response Concatenation Layer
+- [ ] StringBuilder with estimated capacity
+- [ ] Don't use `+` concatenation in loops
+- [ ] Use JTE for complex templates (compile-time optimization)
+
+### Async Orchestration Layer
+- [ ] Parallelize independent steps
+- [ ] Use dedicated thread pool for LLM calls (don't use commonPool)
+- [ ] Use Reactor for streaming + complex orchestration
+
+## Reference Documentation
+
+- In-project general performance: `../SKILL.md`
+- In-project code-level optimization: `code_level_optimization.md` (collections / reflection / lock details)
+- In-project JMH details: `jmh_profiling.md`
+- OkHttp documentation: `https://square.github.io/okhttp/`
+- Jackson performance: `https://github.com/FasterXML/jackson-docs`
+- JTE template: `https://github.com/jknack/jte`
+- LLM streaming response: `https://platform.openai.com/docs/api-reference/chat-streaming`

--- a/.claude/skills/performance-tuning/references/code_level_optimization.md
+++ b/.claude/skills/performance-tuning/references/code_level_optimization.md
@@ -1,0 +1,647 @@
+# Code-Level Performance Optimization
+
+This file supplements SKILL.md's code-level performance content, providing in-depth coverage of collections/Stream/reflection/locks/escape analysis details. Read on demand when users ask "is this coding pattern fast" or "why is this code slow".
+
+## Collection Selection Details
+
+### List Selection
+
+| Implementation | Underlying | Random Access | Head Insert | Tail Insert | Middle Insert | Memory |
+|---|---|---|---|---|---|---|
+| `ArrayList` | Array | O(1) | O(n) | Amortized O(1) | O(n) | Compact |
+| `LinkedList` | Doubly-linked list | O(n) | O(1) | O(1) | O(1) (known position) | Large (node overhead) |
+| `CopyOnWriteArrayList` | Array (copy-on-write) | O(1) | O(n) | O(n) | O(n) | Doubles on write |
+| `ArrayDeque` | Circular array | O(1) | O(1) | O(1) | O(n) | Compact |
+
+**Selection decision**:
+- **Default to `ArrayList`**: Best for 90% of scenarios
+- **Frequent head insert/delete**: `ArrayDeque` (use as List or as Deque)
+- **Very few writes, many reads**: `CopyOnWriteArrayList`
+- **Don't use `LinkedList`**: In 99% of scenarios it's worse than `ArrayList` or `ArrayDeque`; the only fit is "frequent middle insert at known position where array shifting is unacceptable"
+
+**ArrayList performance details**:
+- `new ArrayList<>()` initial capacity 10, first add triggers resize to 10
+- Resize factor 1.5x: `oldCapacity + (oldCapacity >> 1)`
+- Known size: `new ArrayList<>(expectedSize)` avoids multiple resizes
+- `subList()` returns a view; modifications affect the original List; using subList after structural changes to the original List throws `ConcurrentModificationException`
+
+### Map Selection
+
+| Implementation | Underlying | null key | null val | Concurrent | Notes |
+|---|---|---|---|---|---|
+| `HashMap` | Array + linked list + red-black tree | Yes | Yes | No | Default |
+| `LinkedHashMap` | HashMap + doubly-linked list | Yes | Yes | No | Order preservation / LRU |
+| `TreeMap` | Red-black tree | No | Yes | No | Sorted |
+| `ConcurrentHashMap` | CAS + synchronized per segment | No | No | Yes | High concurrency |
+| `EnumMap` | Array | No | Yes | No | Fastest for enum keys |
+| `IdentityHashMap` | Array (== comparison) | Yes | Yes | No | Reference equality |
+
+**HashMap key parameters**:
+- `loadFactor` default 0.75, space/time balance point
+- `initialCapacity`: default 16; for known size use `new HashMap<>(expectedSize / 0.75 + 1)` to avoid resizing
+- Treeification threshold: linked list >= 8 and array >= 64 -> treeify; < 6 -> degrade to linked list
+
+**HashMap JDK evolution**:
+- JDK7: Array + linked list, hash collision -> linked list, multi-threaded resize forms cycle -> infinite loop
+- JDK8: Array + linked list + red-black tree (>=8 treeify), resize splits linked list, no infinite loop
+- JDK8 hash optimization: high 16 bits XOR low 16 bits `(h ^ (h >>> 16))`, reduces collisions
+
+**ConcurrentHashMap evolution**:
+- JDK7: Segment locks (default 16 segments), concurrency = 16
+- JDK8: CAS + synchronized per bucket (array element), concurrency = number of buckets
+- JDK8+ treeification: collisions >= 8 convert to red-black tree, prevents hash collision attacks
+
+### Set Selection
+
+| Implementation | Underlying | Notes |
+|---|---|---|
+| `HashSet` | HashMap (fixed value) | Default |
+| `LinkedHashSet` | LinkedHashMap | Preserves insertion order |
+| `TreeSet` | TreeMap | Sorted |
+| `EnumSet` | Bit vector | Fastest for enums |
+| `CopyOnWriteArraySet` | CopyOnWriteArrayList | Many reads, very few writes |
+
+### Queue Selection
+
+| Implementation | Blocking | Bounded | Notes |
+|---|---|---|---|
+| `ArrayDeque` | No | No | Single-threaded first choice |
+| `LinkedList` | No | No | Don't use (poor performance) |
+| `PriorityQueue` | No | No | Priority queue (min-heap) |
+| `ArrayBlockingQueue` | Yes | Yes | Bounded, commonly used in production |
+| `LinkedBlockingQueue` | No (unbounded default) / Yes | No / Yes | Executors default |
+| `ConcurrentLinkedQueue` | No | No | Lock-free CAS, high concurrency |
+| `DelayQueue` | Yes | No | Delayed tasks |
+
+**Thread pool queue selection**:
+- Default `LinkedBlockingQueue` unbounded -> task accumulation OOM
+- Bounded `ArrayBlockingQueue` -> paired with rejection policy
+- Priority `PriorityBlockingQueue` -> tasks have priorities
+
+### Large Collection Pitfalls
+
+**Don't load large data into memory all at once**:
+- Million-level data -> use cursor/pagination/Stream
+- DB queries use `LIMIT` + `OFFSET` or cursor
+- File processing uses `BufferedReader` / `Stream<String>`
+
+**Collection iteration removal**:
+- Don't use `for + remove` -> `ConcurrentModificationException`
+- Use `iterator.remove()` or `list.removeIf(pred)` (JDK8+)
+
+## Stream Performance Details
+
+### Stream Is Not a Performance Optimization Tool
+
+Stream's design goal is **readability + parallelization**, not performance. Simple iteration with Stream is mostly slower than for:
+
+| Scenario | for | Stream | parallelStream |
+|---|---|---|---|
+| Small collection (< 1000) simple iteration | 1x | 1.2-2x slower | 5-10x slower |
+| Large collection (> 10000) simple iteration | 1x | 1.1-1.5x slower | Depends |
+| Large collection CPU-intensive transform | 1x | Comparable | May be faster |
+| Large collection with IO | 1x | Comparable | **May be faster** |
+
+**Reasons for being slow**:
+- Boxing overhead (`Stream<Integer>` vs `IntStream`)
+- Iterator/Consumer indirect invocation
+- Stream creation overhead
+- `parallelStream` ForkJoinPool splitting overhead
+
+### Correct Stream Usage
+
+**Use primitive streams to avoid boxing**:
+```java
+// Slow: boxed
+list.stream().mapToInt(Integer::intValue).sum();
+
+// Still slower than for, but faster than boxed stream
+IntStream.range(0, list.size()).map(i -> list.get(i)).sum();
+```
+
+**Use collector instead of manual accumulation**:
+```java
+// Slow: string concatenation
+list.stream().map(...).collect(StringBuilder::new, StringBuilder::append, StringBuilder::append);
+
+// Fast
+list.stream().map(...).collect(Collectors.joining(","));
+```
+
+**Correct groupingBy usage**:
+```java
+// Simple grouping
+Map<Key, List<Item>> byKey = items.stream().collect(groupingBy(Item::key));
+
+// Downstream collector reduces boxing
+Map<Key, Long> countByKey = items.stream().collect(groupingBy(Item::key, counting()));
+
+// Concurrent grouping
+Map<Key, List<Item>> byKey = items.parallelStream().collect(groupingByConcurrent(Item::key));
+```
+
+### When to Use parallelStream
+
+**Conditions for using parallelStream**:
+- Data volume > 10000
+- CPU-intensive (no IO)
+- Tasks have no state dependencies
+- Per-element processing time > 1us
+
+**Anti-patterns**:
+- `list.parallelStream().forEach(x -> db.save(x))` -> DB is the bottleneck, parallel is slower and overwhelms DB
+- `list.parallelStream().filter(...).findFirst()` -> Sequential result, parallel is pointless
+- Small collection parallelStream -> ForkJoin splitting overhead > benefit
+- Using `ThreadLocal` inside `parallelStream` -> Thread switching loses context
+
+**parallelStream shared ForkJoinPool**:
+- All `parallelStream` share commonPool (CPU cores - 1)
+- One task stuck -> entire JVM's parallel streams affected
+- Custom pool: `ForkJoinPool custom = new ForkJoinPool(N); custom.submit(() -> list.parallelStream()...).get()`
+
+## Reflection Optimization Details
+
+### Why Reflection Is Slow
+
+- Method table lookup before invocation
+- Boxing/unboxing
+- Parameter checking (unless `setAccessible(true)`)
+- Security manager checks
+
+### Optimization Path
+
+**Level 0: Cache Method/Field objects**
+
+```java
+// Slow: reflective lookup each time
+for (Item item : items) {
+    Method m = item.getClass().getMethod("getName");
+    String name = (String) m.invoke(item);
+}
+
+// Fast: cache
+private static final Method GET_NAME = initMethod();
+private static Method initMethod() {
+    try {
+        Method m = Item.class.getMethod("getName");
+        m.setAccessible(true);  // Disable access checks
+        return m;
+    } catch (NoSuchMethodException e) { throw new RuntimeException(e); }
+}
+// Usage
+String name = (String) GET_NAME.invoke(item);
+```
+
+**Level 1: setAccessible(true)**
+
+JDK9+ module system requires `--add-opens` to access non-exported packages, otherwise `InaccessibleObjectException`.
+
+**Level 2: MethodHandle**
+
+```java
+MethodHandles.Lookup lookup = MethodHandles.lookup();
+MethodHandle mh = lookup.findVirtual(String.class, "length", MethodType.methodType(int.class));
+int len = (int) mh.invoke("hello");  // Close to direct call
+```
+
+**Level 3: LambdaMetafactory**
+
+Convert MethodHandle to `Function` Lambda, no reflection overhead at runtime:
+
+```java
+MethodHandles.Lookup lookup = MethodHandles.lookup();
+MethodHandle mh = lookup.findVirtual(Item.class, "getName", MethodType.methodType(String.class));
+Function<Item, String> getName = (Function<Item, String>) LambdaMetafactory.metafactory(
+    lookup, "apply", MethodType.methodType(Function.class),
+    MethodType.methodType(Object.class, Object.class),
+    mh, MethodType.methodType(String.class, Item.class)
+).getTarget().invoke();
+// Usage: close to direct call
+String name = getName.apply(item);
+```
+
+**Level 4: Bytecode generation**
+
+- ByteBuddy / CGLIB: Generate subclass at runtime, invocation goes through direct bytecode
+- One-time generation cost is high, invocation is extremely fast
+- Suitable for frameworks (Spring AOP, Hibernate)
+
+### Reflection Anti-patterns
+
+- Reflective Method lookup on hot path each time -> cache it
+- Reflective call to private without `setAccessible(true)` -> security check overhead
+- JDK9+ without `--add-opens` -> module access failure
+
+### Alternatives to Reflection
+
+- **Records** (JDK14+): Auto-generated accessors, no reflection
+- **Sealed class + pattern matching** (JDK17): Types known at compile time, no reflection
+- **VarHandle** (JDK9+): Replaces `Field.set/get` for volatile/ordered access
+
+## Lock Optimization Details
+
+### 4 Levels of Lock Optimization
+
+**Level 1: Lock Elision**
+
+JIT determines through escape analysis that an object doesn't escape the method/thread -> auto-eliminates synchronized:
+
+```java
+// JIT determines sb doesn't escape -> lock elision
+public String concat(String a, String b) {
+    StringBuffer sb = new StringBuffer();  // Local, doesn't escape
+    sb.append(a).append(b);
+    return sb.toString();
+}
+```
+
+**Trigger condition**: Escape analysis enabled `-XX:+DoEscapeAnalysis` (enabled by default since JDK8)
+
+**Level 2: Lock Coarsening**
+
+JIT merges adjacent synchronized blocks:
+
+```java
+// Before optimization: lock each iteration
+for (int i = 0; i < n; i++) {
+    synchronized(lock) { ... }
+}
+
+// After lock coarsening: merged outside loop
+synchronized(lock) {
+    for (int i = 0; i < n; i++) { ... }
+}
+```
+
+**Trigger condition**: JIT determines loop's synchronized blocks can be merged.
+
+**Level 3: Lock Granularity Optimization**
+
+```java
+// Coarse-grained: one lock for entire map
+synchronized(map) { ... }
+
+// Fine-grained: segmented locks (JDK7 ConcurrentHashMap)
+// Finer: CAS + bucket-level synchronized (JDK8+ ConcurrentHashMap)
+```
+
+**Level 4: Lock-free**
+
+- Counters: `LongAdder` / `AtomicLong`
+- References: `AtomicReference` / `VarHandle`
+- Parallel computation: `ForkJoinPool` / `CompletableFuture`
+
+### synchronized vs ReentrantLock
+
+| Dimension | synchronized | ReentrantLock |
+|---|---|---|
+| Performance | JDK6+ comparable | Slightly slower (except under high contention) |
+| Interruptible | No | `lockInterruptibly()` |
+| Timeout | No | `tryLock(timeout)` |
+| Fairness | Unfair | Optional fair |
+| Condition queues | 1 (wait/notify) | Multiple `Condition` |
+| Lock release | Automatic (exit block) | Must `finally` explicit unlock |
+
+**Selection**:
+- Simple mutual exclusion -> `synchronized`
+- Need timeout/interrupt/multiple conditions -> `ReentrantLock`
+- Don't switch to `ReentrantLock` just for "performance"; JDK6+ synchronized is well-optimized
+
+### StampedLock
+
+Added in JDK8, optimistic read lock; faster than `ReentrantReadWriteLock` for read-many-write-few scenarios.
+
+```java
+StampedLock sl = new StampedLock();
+long stamp = sl.tryOptimisticRead();  // Optimistic read, no CAS
+int x = currentX;
+int y = currentY;
+if (!sl.validate(stamp)) {  // Validate if written during read
+    stamp = sl.readLock();  // Upgrade to pessimistic read on failure
+    try { x = currentX; y = currentY; }
+    finally { sl.unlockRead(stamp); }
+}
+// Use x, y
+```
+
+**Notes**:
+- Not reentrant! Same thread calling `readLock()` again will deadlock
+- Optimistic read suits "many reads, very few writes"
+- Write lock is exclusive, mutually exclusive with read lock
+
+### LongAdder vs AtomicLong
+
+| Scenario | AtomicLong | LongAdder |
+|---|---|---|
+| Low contention | Fast | Slightly slower (more fields) |
+| High contention | Slow (CAS retries) | 5-10x faster (striped accumulation) |
+| Memory | 1 long | Multiple Cells + base |
+
+**Principle**: LongAdder splits a single counter into multiple Cells; threads disperse to different Cells for CAS, then `sum()` accumulates. The more contention, the faster.
+
+**Scenario**: High-concurrency counters, statistics, rate limiting -> `LongAdder`
+
+### Lock Optimization Key Points
+
+**Reduce lock holding time**:
+```java
+// Slow: hold lock for entire method
+synchronized(lock) {
+    data = loadData();  // IO slow, but holding lock
+    process(data);
+}
+
+// Fast: reduce lock scope
+data = loadData();  // Not holding lock
+synchronized(lock) {
+    process(data);
+}
+```
+
+**Lock separation**:
+```java
+// One big lock
+synchronized(lock) { readA(); writeB(); }
+
+// Separate into two locks
+synchronized(lockA) { readA(); }
+synchronized(lockB) { writeB(); }
+```
+
+**Avoid hotspot fields**:
+- `AtomicInteger` increment under multi-core CPU high contention -> use `LongAdder`
+
+## Escape Analysis and Stack Allocation
+
+### Escape Analysis Levels
+
+JIT determines through Escape Analysis whether an object escapes:
+
+| Level | Description | JIT Behavior |
+|---|---|---|
+| NoEscape | Doesn't escape | Stack allocation + scalar replacement -> no heap, no GC |
+| ArgEscape | Only passed as argument to callee | Heap allocation, but not visible to caller |
+| MethodEscape | Escapes the method | Heap allocation |
+| ThreadEscape | Escapes to other threads | Heap allocation, need to consider visibility |
+
+### Scalar Replacement
+
+Object doesn't escape -> JIT splits object fields into independent local variables:
+
+```java
+// Before optimization
+class Point { int x, y; }
+int sum() {
+    Point p = new Point(1, 2);
+    return p.x + p.y;
+}
+
+// After scalar replacement
+int sum() {
+    int x = 1, y = 2;  // Object disappears
+    return x + y;
+}
+```
+
+**Benefit**: Object doesn't enter heap, no GC pressure, no memory allocation overhead.
+
+### Helping Escape Analysis
+
+- Don't return `new` small objects on hot paths (encourage reuse)
+- Don't assign temporary objects to static fields
+- Don't create large objects in loops
+- Don't let local objects escape into lambda/anonymous inner classes
+
+### Anti-patterns
+
+- `new` temporary objects on hot path each time -> escape analysis may eliminate, but don't rely on it
+- Putting objects into ThreadLocal on hot path -> escapes to thread
+- Putting objects into collections on hot path -> escapes
+
+### Confirming JIT Behavior
+
+Confirm whether escape analysis is effective:
+```bash
+# Startup parameters
+-XX:+DoEscapeAnalysis -XX:+PrintEscapeAnalysis -XX:+PrintInlining
+```
+
+Note: Escape analysis requires JIT warmup; short-running applications may not benefit.
+
+## String Optimization
+
+### StringBuilder vs +
+
+- `+` inside loop -> compiled to `new StringBuilder().append().append()`, new instance each iteration
+- Outside loop or simple concatenation -> compiler optimizes to single StringBuilder
+- Complex multi-line concatenation -> explicit `StringBuilder`
+
+```java
+// Slow: + inside loop
+String s = "";
+for (String x : list) s += x;  // New StringBuilder each iteration
+
+// Fast: StringBuilder outside loop
+StringBuilder sb = new StringBuilder();
+for (String x : list) sb.append(x);
+String s = sb.toString();
+```
+
+### String Constant Pool
+
+- `intern()` puts into constant pool, same strings are reused
+- JDK7+ constant pool is in heap, won't cause PermGen/Metaspace OOM
+- Don't overuse `intern()`, may bloat the constant pool
+- Comparison: `==` is unreliable, use `equals()`
+
+### String Encoding
+
+- `String` internally UTF-16, 2 bytes per character
+- ASCII strings use `byte[]` + Latin-1 encoding (JDK9+ Compact Strings)
+- For heavy ASCII string processing, consider direct `byte[]` manipulation
+
+## Object Pooling and Reuse
+
+### Don't Overuse Object Pools
+
+JDK 17's young GC is very fast; allocation + reclamation is cheaper than pool maintenance overhead.
+
+| Scenario | Use Pool | Don't Use Pool |
+|---|---|---|
+| Regular POJO | No | Yes |
+| JDBC Connection | Yes | |
+| Thread | Yes (ThreadPool) | |
+| Large object (> few KB) | Depends | |
+| Buffer / ByteBuffer | Yes (Netty Pool) | |
+
+**Judgment**: Only use pools when allocation overhead > pool maintenance overhead. In most scenarios GC is faster than pools.
+
+### ThreadLocal Reuse
+
+```java
+private static final ThreadLocal<SimpleDateFormat> TL = ThreadLocal.withInitial(
+    () -> new SimpleDateFormat("yyyy-MM-dd")
+);
+// Reuse
+TL.get().format(date);
+```
+
+Note: In thread pool scenarios, ThreadLocal must call `remove()`, otherwise data persists after thread reuse.
+
+**JDK 17 alternative**: Use `DateTimeFormatter` (thread-safe, no ThreadLocal needed):
+```java
+private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+String s = FMT.format(LocalDate.now());
+```
+
+## JDK 17 New Features (Performance-Related)
+
+### Records (JDK 14+ stable)
+
+Compiler auto-generates equals/hashCode/toString, faster than reflection or Lombok:
+
+```java
+public record Point(int x, int y) {}
+```
+
+**Performance benefits**:
+- No reflection overhead
+- Compiler-generated `equals`/`hashCode` is faster than Lombok `@Data` (Lombok uses reflection in some scenarios)
+- Immutable -> can be eliminated by escape analysis
+
+**Applicable to**: DTOs, value objects, configuration classes.
+
+### Sealed Class (JDK 17 stable)
+
+Compile-time exhaustive matching, helps JIT devirtualization:
+
+```java
+public sealed interface Shape
+    permits Circle, Rectangle, Triangle {}
+
+public final class Circle implements Shape { ... }
+public final class Rectangle implements Shape { ... }
+public final class Triangle implements Shape { ... }
+
+// Compile-time exhaustive
+public double area(Shape s) {
+    return switch (s) {
+        case Circle c -> Math.PI * c.r() * c.r();
+        case Rectangle r -> r.w() * r.h();
+        case Triangle t -> t.b() * t.h() / 2;
+    };
+}
+```
+
+**Performance benefits**:
+- All implementations known at compile time -> JIT monomorphic/bimorphic inlining
+- Pattern matching is faster than `instanceof` chains
+- Switch uses `tableswitch` (jump table), faster than `lookupswitch`
+
+### Module System and --add-opens (JDK 17 Must-Know)
+
+JDK 9+ module system; reflective access to non-exported packages requires `--add-opens`:
+
+```
+--add-opens java.base/java.lang=ALL-UNNAMED
+--add-opens java.base/java.util=ALL-UNNAMED
+--add-opens java.base/java.nio=ALL-UNNAMED
+```
+
+**Error keyword**: `InaccessibleObjectException` -> missing `--add-opens`.
+
+**Typical scenarios**:
+- Spring / Hibernate / ByteBuddy reflection -> need `--add-opens`
+- Netty accessing NIO internals -> `--add-opens java.base/java.nio`
+- `Unsafe` or reflection accessing `String.value` -> `--add-opens java.base/java.lang`
+
+### Foreign Memory Access API (incubator)
+
+JDK 17 incubator (`--add-modules jdk.incubator.foreign`), official replacement for off-heap memory access, replacing `ByteBuffer.allocateDirect` + `sun.misc.Unsafe`:
+
+```java
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+
+try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+    MemorySegment seg = MemorySegment.allocateNative(100, scope);
+    seg.set(ValueLayout.JAVA_INT, 0, 42);
+    int val = seg.get(ValueLayout.JAVA_INT, 0);
+}
+```
+
+**Benefits**:
+- Faster than `ByteBuffer.allocateDirect` (no cleaner dependency)
+- Safer than `Unsafe` (has bounds checking)
+- Automatic release (ResourceScope)
+
+**Note**: JDK 17 incubator, API may change. JDK 19+ stable.
+
+### Vector API (incubator)
+
+JDK 17 incubator (`--add-modules jdk.incubator.vector`), SIMD syntax, replacing hand-written loop vectorization:
+
+```java
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorSpecies;
+
+static final VectorSpecies<Float> SPECIES = FloatVector.SPECIES_256;
+
+void vectorAdd(float[] a, float[] b, float[] c) {
+    int i = 0;
+    int upper = SPECIES.loopBound(a.length);
+    for (; i < upper; i += SPECIES.length()) {
+        FloatVector va = FloatVector.fromArray(SPECIES, a, i);
+        FloatVector vb = FloatVector.fromArray(SPECIES, b, i);
+        va.add(vb).intoArray(c, i);
+    }
+    for (; i < a.length; i++) c[i] = a[i] + b[i];
+}
+```
+
+**Benefit**: Explicit SIMD, more stable than C2 auto-vectorization. JDK 17 still incubator.
+
+**Note**: JDK 17 incubator, API may change. JDK 19+ preview.
+
+### Virtual Threads (JDK 21+, Not Available in JDK 17)
+
+**Important**: Virtual threads are only stable in JDK 21+, not available in JDK 17.
+
+JDK 17 alternatives: Use `CompletableFuture` / `Reactor` / `RxJava` for async orchestration.
+
+After upgrading to JDK 21+:
+```java
+// JDK 21+
+Thread.startVirtualThread(() -> { ... });
+
+try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    IntStream.range(0, 10000).forEach(i ->
+        executor.submit(() -> { handleRequest(i); return null; })
+    );
+}
+```
+
+**Benefits**: Million-level threads, 5-10x throughput for IO-intensive scenarios.
+**Limitations**: No benefit for CPU-intensive; synchronized holding pins thread (JDK 21 solution: use `ReentrantLock`).
+
+## Common Anti-Pattern Quick Reference
+
+| Anti-Pattern | Problem | Correct Approach |
+|---|---|---|
+| `new` large object in loop | Frequent GC | Move outside loop, or use object pool |
+| `LinkedList` as List | Poor performance | `ArrayList` |
+| `HashMap` + `synchronized` | Coarse lock granularity | `ConcurrentHashMap` |
+| `Vector` / `Hashtable` | All-method locking | `CopyOnWriteArrayList` / `ConcurrentHashMap` |
+| Stream for simple iteration | Boxing overhead | for loop |
+| `parallelStream` with IO inside | Blocks shared ForkJoinPool | Async + custom pool |
+| Reflection without caching Method | Reflection overhead | static final cache |
+| Shared `SimpleDateFormat` | Not thread-safe | ThreadLocal or `DateTimeFormatter` |
+| `+` string concatenation in loop | New StringBuilder each time | Explicit StringBuilder |
+| `==` for string comparison | Unreliable | `equals()` |
+| JDK 17 reflection without `--add-opens` | `InaccessibleObjectException` | Add `--add-opens` JVM parameter |
+| JDK 17 shared `SimpleDateFormat` | Not thread-safe | `DateTimeFormatter` (thread-safe) |
+| JDK 17 waiting for JIT auto-vectorization | Unstable | Vector API incubator (explicit SIMD) |
+| JDK 17 pooling large objects | GC is fast enough | Don't pool; escape analysis eliminates |
+| JDK 17 using Lombok @Data | Reflection in some scenarios | Records (compiler-generated) |
+| JDK 17 `instanceof` chain + cast | Multiple type checks | sealed + pattern matching |
+| JDK 17 off-heap memory with `Unsafe` | Unsafe | Foreign Memory API (incubator) |

--- a/.claude/skills/performance-tuning/references/gc_tuning.md
+++ b/.claude/skills/performance-tuning/references/gc_tuning.md
@@ -1,0 +1,314 @@
+# GC Tuning Guide (Proactive, JDK 17 baseline)
+
+This file supplements SKILL.md's GC tuning content, **using JDK 17 as the baseline**, focusing on **proactive configuration** (how to select GC and tune parameters to prevent issues). For reactive troubleshooting (when GC is already frequent), see `../../jvm-troubleshoot/references/gc_tuning_guide.md`.
+
+**Boundary between the two skills**:
+- jvm-troubleshoot/gc_tuning_guide: Reactive troubleshooting (frequent Full GC, GC overhead limit) -> locate + fix
+- This file: Proactive configuration (select GC and tune parameters before deployment) -> prevent
+
+## Heap Generational Review
+
+```
++--------------------------------------------------+
+|                        Heap                       |
++-----------------------------+--------------------+
+|       Young Generation      |   Old Generation   |
+|  +-------+-------+-------+ |                    |
+|  | Eden  | S0    | S1    | |                    |
+|  +-------+-------+-------+ |                    |
++-----------------------------+--------------------+
+              +------------------+
+              | Metaspace (non-heap) |  Class metadata
+              +------------------+
+```
+
+**Core tuning philosophy**:
+- Let objects be reclaimed in the young generation as much as possible (short-lived objects)
+- Avoid premature promotion to old generation
+- Reduce Full GC (Full GC = STW long pause)
+
+## JDK 17 GC Collector Status
+
+JDK 17 stable collectors:
+
+| Collector | Status | Algorithm | Pause | Applicable |
+|---|---|---|---|---|
+| **G1** | Default | Region-based + mark-compact | Short controllable (200ms target) | General, medium heap |
+| **ZGC** | Stable (JDK 15+) | Colored pointers + read barrier | Sub-millisecond | Large heap, low latency |
+| **Shenandoah** | Stable (JDK 15+) | Brooks pointer + concurrent compaction | Sub-millisecond | Large heap, low latency |
+| **Parallel** | Stable | Multi-threaded parallel | Medium | Throughput-first |
+| **Serial** | Stable | Single-threaded | Long | Client, small applications |
+| **CMS** | **Removed** (JDK 14) | - | - | Upgrade to G1 |
+
+**JDK 17 key points**:
+- ZGC is the **non-generational version** (generational ZGC is stable only in JDK 21+). Non-generational version has throughput impact; for very large heap scenarios consider upgrading to JDK 21
+- Shenandoah is stable in OpenJDK builds; Oracle JDK does not include Shenandoah
+- G1 remains the default, sufficient for most scenarios
+
+## GC Collector Selection (Proactive Decision)
+
+### Select by Scenario
+
+| Scenario | Heap Size | Pause Requirement | Recommended Collector | Key Parameters |
+|---|---|---|---|---|
+| Microservice / Default | < 4GB | Within 200ms | G1 | `-XX:MaxGCPauseMillis=200` |
+| Medium application | 4-8GB | Within 200ms | G1 | `-XX:MaxGCPauseMillis=200 -XX:G1HeapRegionSize=8m` |
+| Large low-latency | 8-32GB | Within 50ms | ZGC | `-XX:+UseZGC -XX:ZAllocationSpikeTolerance=2` |
+| Very large heap | 32GB-16TB | Sub-millisecond | ZGC | `-XX:+UseZGC` |
+| High throughput batch | Any | No pause requirement | Parallel | `-XX:+UseParallelGC -XX:ParallelGCThreads=N` |
+| Low pause + concurrent marking | Medium | Within 100ms | Shenandoah (OpenJDK) | `-XX:+UseShenandoahGC` |
+
+### Selection Decision Tree
+
+1. JDK 17 + heap >= 8GB + low latency -> **ZGC**
+2. JDK 17 + heap < 8GB -> **G1** (default)
+3. Throughput first (offline computation) -> **Parallel**
+4. Heap > 32GB + throughput-sensitive -> upgrade to JDK 21 for generational ZGC
+
+**Do not**:
+- Use ZGC with heap < 4GB -> no benefit, actually slower
+- Switch collectors without measuring -> might be slower
+- Set `-XX:MaxGCPauseMillis=1` -> mostly unachievable, causes frequent GC instead
+
+## G1 Tuning
+
+G1 is the JDK 17 default collector; most scenarios don't need manual tuning.
+
+### G1 Working Principle
+
+- Heap divided into regions (1MB-32MB, default adapts to heap size)
+- Young generation = set of regions (dynamically adjusted)
+- Old generation = set of regions
+- Large objects = humongous region (object > 50% of region)
+- Mixed GC: selectively reclaim old generation regions
+
+### G1 Key Parameters
+
+| Parameter | Default | Tuning Suggestion |
+|---|---|---|
+| `-XX:MaxGCPauseMillis` | 200 | Actual SLA pause * 0.8 |
+| `-XX:G1HeapRegionSize` | Adaptive | Explicitly set 8m-32m |
+| `-XX:InitiatingHeapOccupancyPercent` | 45 | Old generation occupancy triggers concurrent marking; lower triggers earlier |
+| `-XX:G1NewSizePercent` | 5 | Young generation lower bound |
+| `-XX:G1MaxNewSizePercent` | 60 | Young generation upper bound |
+| `-XX:G1MixedGCCountTarget` | 8 | How many Mixed GC rounds to complete |
+| `-XX:G1MixedGCLiveThresholdPercent` | 85 | Region live object ratio > this value won't be reclaimed |
+
+### G1 Tuning Scenarios
+
+**Scenario 1: Frequent Full GC**
+
+Cause: Old generation growing too fast, Mixed GC can't keep up.
+
+Tuning:
+- Lower `-XX:InitiatingHeapOccupancyPercent=35` (trigger concurrent marking earlier)
+- Raise `-XX:G1MixedGCCountTarget=16` (more Mixed GC rounds)
+- Raise `-XX:G1MixedGCLiveThresholdPercent=90` (more` (more regions eligible for reclamation)
+
+**Scenario 2: Long Young GC Pause**
+
+Cause: Eden too large, single reclamation takes long.
+
+Tuning:
+- Lower `-XX:MaxGCPauseMillis=100`
+- Lower `-XX:G1MaxNewSizePercent=40`
+
+**Scenario 3: Frequent Humongous Allocation**
+
+Cause: Many large objects occupy humongous regions; only reclaimed during Mixed GC.
+
+Tuning:
+- Increase `-XX:G1HeapRegionSize=16m` or `32m` (reduce humongous allocations)
+- Application level: reduce large object allocation, or use object pooling
+
+## ZGC Tuning (JDK 17 Non-Generational Version)
+
+Production-ready since JDK 15. JDK 17 is the **non-generational version**; pause doesn't grow with heap (sub-millisecond), suitable for large heaps.
+
+### ZGC Working Principle
+
+- Colored pointers (multi-view mapping)
+- Read barrier (application threads do concurrent marking)
+- Almost entirely concurrent; STW only has a few short pauses (initial mark, remark, relocation)
+
+### JDK 17 vs JDK 21+ ZGC
+
+| Dimension | JDK 17 (Non-generational) | JDK 21+ (Generational) |
+|---|---|---|
+| Algorithm | Whole-heap concurrent | Generational + concurrent |
+| Throughput | Slightly lower (scans entire heap) | Higher (only scans young generation) |
+| Pause | Sub-millisecond | Sub-millisecond |
+| Heap size | Any | Any |
+
+**Recommendation**: Heap > 32GB + throughput-sensitive -> upgrade to JDK 21 for generational ZGC. Otherwise JDK 17 non-generational ZGC is sufficient.
+
+### ZGC Key Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `-XX:ZAllocationSpikeTolerance` | 2 | Allocation spike tolerance |
+| `-XX:ConcGCThreads` | ParallelGCThreads / 4 | Concurrent GC thread count |
+| `-XX:ZUncommitDelay` | 300 | Uncommitted memory reclamation delay (seconds) |
+
+### ZGC Tuning Scenarios
+
+**Concurrent marking consuming CPU**:
+- Increase `-XX:ConcGCThreads` (more concurrent GC threads)
+- But must not exceed half of physical cores, otherwise application CPU is squeezed
+
+**Allocation spike causing STW**:
+- Increase `-XX:ZAllocationSpikeTolerance=3`
+
+## Parallel GC Tuning
+
+Throughput-first collector. Commonly used for offline computation.
+
+### Parallel Key Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `-XX:ParallelGCThreads` | CPU cores * 5/8 | GC thread count |
+| `-XX:MaxGCPauseMillis` | No upper limit | Target pause (not guaranteed) |
+| `-XX:GCTimeRatio` | 99 | GC time ratio = 1/(1+N) -> 1% |
+| `-XX:UseParallelOldGC` | JDK 17 default | Old generation parallel collection |
+
+### Parallel Tuning Scenarios
+
+**Throughput first**:
+- Don't set `-XX:MaxGCPauseMillis` (let GC run freely)
+- Increase young generation: `-XX:NewRatio=1` (young generation = half of old generation)
+
+**Reduce GC frequency**:
+- Increase heap
+- Increase young generation
+- Increase `-XX:GCTimeRatio=99` (allow 1% GC time ratio)
+
+## General GC Tuning Principles
+
+### Principle 1: Tune the Application First, Then GC
+
+GC tuning has limited benefit. Optimize the application layer first (algorithms, data structures, allocation hotspots), then tune GC parameters.
+
+### Principle 2: Bigger Heap Is Not Always Better
+
+- Large heap -> longer single GC time (for non-concurrent collectors)
+- Large heap -> exceeding 32GB disables compressed oops
+- 32GB+ heap use ZGC / Shenandoah (concurrent, pause doesn't grow with heap)
+
+### Principle 3: Avoid Premature Promotion
+
+Objects reclaimed in young generation are better than entering old generation.
+
+- Increase young generation (`-XX:NewRatio=1`)
+- Increase Survivor (`-XX:SurvivorRatio=6`)
+- Increase promotion age (`-XX:MaxTenuringThreshold=15`)
+
+### Principle 4: Monitor GC Logs
+
+GC logs must be enabled (JDK 17 unified logging syntax):
+
+```
+-Xlog:gc*:file=gc.log:time,uptime:filecount=10,filesize=10M
+```
+
+Periodically analyze with GCViewer / gceasy.io.
+
+### Principle 5: Test and Verify
+
+GC parameter changes require testing:
+- Run actual traffic with JFR / container load testing
+- Compare GC log throughput, pauses, Full GC frequency
+- Don't stop until target is met
+
+## GC Tuning Scenario Quick Reference
+
+| Scenario | Tuning |
+|---|---|
+| Frequent Full GC | Increase heap / lower IHOP / fix memory leak |
+| Frequent Young GC | Increase young generation |
+| Long Young GC pause | Decrease young generation / lower MaxGCPauseMillis |
+| GC throughput > 10% | Increase heap / switch GC / fix application |
+| Metaspace full | Adjust `-XX:MaxMetaspaceSize` |
+| Direct memory full | Adjust `-XX:MaxDirectMemorySize` |
+
+## Production Environment Recommended Configuration
+
+### Microservice (JDK 17, Container)
+
+```
+-XX:+UseContainerSupport
+-XX:InitialRAMPercentage=50.0
+-XX:MaxRAMPercentage=75.0
+-XX:+UseG1GC
+-XX:MaxGCPauseMillis=200
+-XX:MetaspaceSize=256m
+-XX:MaxMetaspaceSize=512m
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath=/var/log/dumps/
+-Xlog:gc*:file=/var/log/gc.log:time,uptime:filecount=10,filesize=10M
+-XX:+AlwaysPreTouch
+-XX:+DisableExplicitGC
+```
+
+### Large Low-Latency (JDK 17, Physical Machine)
+
+```
+-Xms32g -Xmx32g
+-XX:+UseZGC                          # JDK 17 non-generational ZGC
+-XX:ZAllocationSpikeTolerance=2
+-XX:ConcGCThreads=8
+-XX:MetaspaceSize=512m
+-XX:MaxMetaspaceSize=1g
+-XX:ReservedCodeCacheSize=512m
+-XX:+HeapDumpOnOutOfMemoryError
+-Xlog:gc*:file=/var/log/gc.log:time,uptime:filecount=20,filesize=50M
+```
+
+### High Throughput Batch Processing (JDK 17)
+
+```
+-Xms16g -Xmx16g
+-XX:+UseParallelGC
+-XX:ParallelGCThreads=16
+-XX:NewRatio=1
+-XX:+AlwaysPreTouch
+```
+
+## GC Log Analysis (JDK 17 Unified Syntax)
+
+### Key Metrics
+
+- **GC throughput**: Application time / total time (should be > 95%)
+- **Average pause**: Average of all GC pauses
+- **Maximum pause**: Single longest pause
+- **Full GC frequency**: Normally once every few hours; once every few minutes is problematic
+- **Old generation occupancy**: Should be able to drop back after stabilizing; if not = memory leak
+
+### Tools
+
+- **GCViewer** (open source): `https://github.com/chewiebug/GCViewer`
+- **gceasy.io** (online): Upload GC log for automatic analysis
+- **JFR**: `jdk.GarbageCollection` events
+
+### JDK 17 Log Syntax
+
+```
+-Xlog:gc*:file=gc.log:time,uptime:filecount=10,filesize=10M
+```
+
+- `gc*`: All GC-related tags
+- `time,uptime`: Log format (timestamp + seconds since startup)
+- `filecount=10,filesize=10M`: Rolling log, 10 files x 10MB
+
+**Online GC log viewing / real-time diagnostic commands**: Belongs to jvm-troubleshoot skill, see `../../jvm-troubleshoot/references/diagnostic_commands.md` and `gc_tuning_guide.md` (reactive troubleshooting perspective).
+
+## Reference Documentation
+
+- In-project reactive troubleshooting: `../../jvm-troubleshoot/references/gc_tuning_guide.md`
+- In-project diagnostic commands: `../../jvm-troubleshoot/references/diagnostic_commands.md`
+- Oracle JDK 17 GC tuning: `https://docs.oracle.com/en/java/javase/17/gctuning/`
+- G1 tuning: `https://docs.oracle.com/en/java/javase/17/gctuning/garbage-first-garbage-collector.html`
+- ZGC: `https://wiki.openjdk.org/display/zgc`
+- ZGC generational design (JEP 439): `https://openjdk.org/jeps/439`
+- Shenandoah: `https://wiki.openjdk.org/display/shenandoah`
+- GC log analysis: `https://gceasy.io/`

--- a/.claude/skills/performance-tuning/references/jit_compiler.md
+++ b/.claude/skills/performance-tuning/references/jit_compiler.md
@@ -1,0 +1,493 @@
+# JIT and Compilation Optimization
+
+This file supplements SKILL.md's compilation optimization content, providing in-depth coverage of JIT tiered compilation, inlining, loop unrolling, C2 vs Graal, etc. Read on demand when users ask "how does JIT work" or "why does it get faster after warmup".
+
+## JIT Basic Principles
+
+JVM interprets bytecode -> collects method invocation frequency -> hot methods trigger JIT compilation -> compiled code executes as machine code directly.
+
+**Advantages**:
+- Interpreted execution has fast startup; compiled execution has fast runtime
+- JIT does aggressive optimization based on runtime profiling (virtual method monomorphization, branch prediction)
+- Has an advantage over AOT (C++) through runtime feedback
+
+**Disadvantages**:
+- Warmup overhead
+- Single compilation may be deoptimized due to inaccurate profile
+
+## Tiered Compilation
+
+JDK8+ enables `-XX:+TieredCompilation` by default; JVM uses 5 compilation tiers:
+
+| Tier | Interpreter | C1 | C2 | Purpose |
+|---|---|---|---|---|
+| 0 | Yes | | | Interpreted execution, collects profile |
+| 1 | | Yes | | C1 compiled, no profile |
+| 2 | | Yes | | C1 + lightweight profile |
+| 3 | | Yes | | C1 + full profile (most methods stop here) |
+| 4 | | | Yes | C2 compiled, aggressive optimization |
+
+**Flow**:
+1. Method starts at tier 0 in interpreted mode
+2. Invocation count reaches threshold -> tier 3 (C1 + profile)
+3. C2 queue compiles -> tier 4 (C2 aggressive optimization)
+4. Profile invalidated (e.g., new virtual method branch) -> deoptimize back to tier 0
+
+**Thresholds**:
+- Tier 3: ~1500 invocations
+- Tier 4: ~10000 invocations (adaptive under tiered compilation)
+
+### C1 (Client Compiler)
+
+- Fast compilation, medium code quality
+- Simple optimizations: method inlining, constant folding
+- Suitable for short-running applications / CLI
+
+### C2 (Server Compiler)
+
+- Slow compilation, aggressive optimization
+- Advanced optimizations: escape analysis + scalar replacement + lock elision + loop unrolling + virtual method monomorphization
+- Suitable for long-running applications
+
+### Graal (JDK10+ experimental)
+
+- Java-written C2 replacement
+- More aggressive optimizations (20%+ faster than C2 in some scenarios)
+- Enable: `-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler`
+- Partially stable in JDK17+, but still experimental
+
+## Inlining
+
+Inlining is JIT's most important optimization: replacing method calls with the method body itself, saving call overhead + enabling subsequent optimizations.
+
+### Inlining Benefits
+
+- Save call overhead (stack frame, parameter passing)
+- After inlining, more optimizations become possible (constant folding, dead code elimination)
+- Prerequisite for other optimizations (escape analysis depends on inlining)
+
+### Inlining Conditions
+
+| Condition | Default Value | Description |
+|---|---|---|
+| Method size | < 35 bytecodes (`-XX:MaxInlineSize`) | Small methods prioritized |
+| Frequency | Hot (> CompileThreshold) | High invocation frequency |
+| Type statically determinable | Non-virtual / single-implementation virtual | Virtual method inlining requires CHA (Class Hierarchy Analysis) |
+
+### Virtual Method Inlining
+
+Virtual methods (non-final, non-private) cannot be inlined by default -- JIT doesn't know which implementation at runtime. But JIT uses CHA (Class Hierarchy Analysis):
+
+- **Monomorphic**: Only one implementation of the method -> inline
+- **Bimorphic**: Two implementations -> inline + branch
+- **Megamorphic**: > 2 implementations -> no inlining, virtual method table lookup
+
+**Help inlining**:
+- Add `final` to classes/methods -> compile-time determines non-virtual call
+- Avoid unnecessary interfaces (let JIT determine monomorphic)
+- Don't use complex inheritance hierarchies on hot paths
+
+### -XX:MaxInlineSize vs -XX:FreqInlineSize
+
+- `MaxInlineSize=35`: Regular method inlining upper limit
+- `FreqInlineSize=325`: Hot method inlining upper limit (larger methods can still be inlined if hot)
+
+### Inlining Log
+
+```bash
+-XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining
+```
+
+Output looks like:
+```
+  @ 27   java.lang.String::hashCode (49 bytes)   inline (hot)
+  @ 12   java.util.HashMap::getNode (110 bytes)   inline (hot)
+  @ 7   com.foo.Bar::cachedCall (5 bytes)   inline (hot)
+```
+
+`inline (hot)` = inlining succeeded; `too big` = method too large; `not inline (no static binding)` = polymorphic.
+
+## Loop Optimization
+
+### Loop Unrolling
+
+Copy the loop body multiple times to reduce loop overhead:
+
+```java
+// Before optimization
+for (int i = 0; i < 1000; i++) { ... }
+
+// After unrolling (4 iterations of work per loop)
+for (int i = 0; i < 1000; i += 4) {
+    body(); body(); body(); body();
+}
+```
+
+C2 unrolls small loops by default; adjust via `-XX:LoopMaxUnroll=64`.
+
+### Loop Peeling
+
+Peel off the first/last iteration of the loop to simplify the middle loop.
+
+### Loop Vectorization
+
+C2 converts contiguous operations into SIMD instructions:
+
+```java
+// Array element-wise addition
+for (int i = 0; i < n; i++) {
+    c[i] = a[i] + b[i];
+}
+
+// After vectorization (CPU SIMD instructions, process 4-16 at once)
+// c[i:i+8] = a[i:i+8] + b[i:i+8]
+```
+
+**Trigger conditions**:
+- Contiguous array access
+- Primitive element types (int/long/float/double)
+- Simple loop body
+- No dependencies (previous result doesn't affect next)
+
+### Loop Unrolling Limitations
+
+- Too large won't unroll (default <= 64 bytecodes)
+- Exceptions prevent unrolling
+- Synchronized blocks prevent unrolling
+
+## Escape Analysis and Optimization
+
+Escape analysis is C2's core optimization; see `code_level_optimization.md`'s "Escape Analysis" section for details.
+
+**Core benefits**:
+- Stack allocation -> no heap, no GC
+- Scalar replacement -> object fields split into local variables
+- Lock elision -> uncontended locks eliminated
+
+**Parameters**:
+- `-XX:+DoEscapeAnalysis` (enabled by default since JDK8)
+- `-XX:+EliminateAllocations`: Stack allocation (depends on escape analysis, enabled by default)
+- `-XX:+EliminateLocks`: Lock elision (depends on escape analysis, enabled by default)
+
+## Branch Prediction
+
+JIT uses profile data for branch prediction:
+
+```java
+if (log.isDebugEnabled()) {  // JIT sees isDebugEnabled mostly returns false
+    log.debug("...");        // Entire if block code is not optimized
+}
+```
+
+**Benefits**:
+- Frequently-taken branch placed first, CPU branch prediction hit rate is high
+- Rarely-taken branch may be treated as "cold" code, performance nearly eliminated
+
+## Devirtualization
+
+Virtual method inlining depends on CHA, but class hierarchy may change at runtime (dynamic loading). JIT conservatively:
+- Inlines monomorphic methods
+- Assumes class hierarchy is stable -> if newly loaded class breaks assumption -> deoptimization
+
+**GraalVM Native Image**: AOT compilation knows all classes at build time, can aggressively devirtualize.
+
+## Deoptimization
+
+JIT does aggressive optimization based on runtime profile. If profile is invalidated -> deoptimize back to interpreted execution.
+
+**Trigger conditions**:
+- Newly loaded class breaks CHA assumption (e.g., new virtual method implementation)
+- Exception path triggered
+- `-XX:+CompileCommand=exclude,Class.method` excludes certain methods
+
+**Manifestation**:
+- Sudden performance drop (compiled version discarded)
+- Re-profiling + recompilation
+
+**Debugging**:
+```bash
+-XX:+TraceDeoptimization
+-XX:+PrintDeoptimization
+```
+
+## Code Cache
+
+JIT-compiled machine code is stored in the Code Cache:
+
+| Parameter | Meaning | Default |
+|---|---|---|
+| `-XX:ReservedCodeCacheSize` | Upper limit | 240M (JDK9+) / 48M (JDK8) |
+| `-XX:InitialCodeCacheSize` | Initial | 160K |
+| `-XX:CodeCacheExpansionSize` | Expansion step | 64K |
+
+**Behavior when full**:
+- No more JIT compilation of new methods -> performance degradation
+- Previously compiled methods may be discarded -> deoptimization
+- No error reported, hard to notice
+
+**Monitoring**:
+```bash
+jcmd <pid> Compiler.CodeCache
+```
+
+**Tuning**:
+- JDK8: Default 48M is too small, recommend 256M
+- JDK9+: Default 240M is sufficient for most cases
+- Large applications (100k+ classes): increase to 512M
+
+## JIT Tuning Parameter Summary
+
+### Enable / Disable
+
+```
+-XX:+TieredCompilation         # Tiered compilation (enabled by default in JDK8+)
+-XX:-TieredCompilation         # Disable, use only C2 (short-running may benefit)
+-XX:+PrintCompilation          # Print JIT compilation log
+-XX:+PrintInlining             # Print inlining decisions (requires +UnlockDiagnosticVMOptions)
+-XX:+PrintCodeCache            # Print Code Cache status
+-XX:+PrintDeoptimization       # Print deoptimization events
+-XX:+TraceClassLoading         # Print class loading
+```
+
+### Thresholds
+
+```
+-XX:CompileThreshold=10000             # C2 compilation threshold
+-XX:BackEdgeThreshold=100000           # OSR threshold (loop back edge)
+-XX:OnStackReplacePercentage=140       # OSR ratio
+-XX:MaxInlineSize=35                   # Max bytecodes for inlined method
+-XX:FreqInlineSize=325                 # Max bytecodes for hot method inlining
+-XX:LoopMaxUnroll=64                   # Max bytecodes for loop unrolling
+```
+
+### Compiler Selection
+
+```
+-XX:+UseC1                      # Use C1 (disable C2)
+-XX:+UseC2                      # Use C2 (disable C1)
+-XX:+UseJVMCICompiler           # Use Graal (experimental)
+-XX:TieredStopAtLevel=4         # Compile up to tier 4 (default)
+-XX:TieredStopAtLevel=1         # Use only C1, stop at tier 1 (short-running)
+```
+
+## Warmup
+
+JIT needs time to warm up:
+- Short-running applications (CLI, batch): May never compile to tier 4 -> slow
+- Long-running applications (services): Stable after warmup
+
+### Short-Running Application Optimization
+
+**Option 1: Tiered compilation + C1 priority**
+```
+-XX:+TieredCompilation -XX:TieredStopAtLevel=1
+```
+
+**Option 2: CDS (Class Data Sharing)**
+```
+# Generate shared archive
+java -Xshare:dump
+
+# Generate shared archive
+java -Xshare:dump
+
+# Use at runtime
+java -Xshare:on -jar app.jar
+```
+
+**Option 3: AppCDS** (Custom class CDS)
+```
+# JDK13+
+java -XX:ArchiveClassesAtExit=app.jsa -cp app.jar App
+
+# Run
+java -XX:SharedArchiveFile=app.jsa -cp app.jar App
+```
+
+**Option 4: GraalVM Native Image**
+```bash
+native-image -jar app.jar app
+./app
+```
+- AOT compilation, millisecond startup, no JIT
+- Suitable for CLI / function computing
+- Sacrifices some peak performance for startup speed
+
+### Long-Running Application Optimization
+
+**Warmup methods**:
+- Send simulated traffic for 5-10 minutes after startup
+- Or manually loop-call hot methods in `main`
+
+**Note**: Production environments with G1/ZGC + tiered compilation default configuration is fine; don't randomly adjust JIT parameters.
+
+## Monitoring JIT Status
+
+```bash
+# View Code Cache usage
+jcmd <pid> Compiler.CodeCache
+
+# View compiled methods
+jcmd <pid> Compiler.list
+
+# View JIT compilation statistics
+jcmd <pid> Compiler.stats
+
+# View C2 queue
+jcmd <pid> Compiler.queue
+
+# View JVM startup parameters
+jcmd <pid> VM.flags
+```
+
+## GraalVM Comparison (JDK 17 baseline)
+
+| Dimension | HotSpot JIT (C1/C2) | GraalVM Native Image | GraalVM JIT (Graal) |
+|---|---|---|---|
+| Compilation timing | Runtime | Build time (AOT) | Runtime (Graal) |
+| Startup speed | Slow | Millisecond-level | Slow |
+| Peak performance | High | Medium (80-95% in some scenarios) | High (20%+ faster than C2 in some scenarios) |
+| Memory usage | High | Low | High |
+| Reflection support | Full | Requires configuration (reachability metadata) | Full |
+| Applicable | Long-running services | CLI / function computing / microservices | Experimental |
+
+**JDK 17 GraalVM Native Image status**:
+- Production-ready
+- Millisecond startup, single binary deployment
+- Reflection requires `reachability-metadata.json` or `@RegisterReflectionForBinding`
+- Spring Boot 3 / Micronaut / Quarkus native support
+- Sacrifices about 5-20% peak performance for startup speed
+
+**Using GraalVM JIT (experimental)**:
+```
+-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler
+```
+
+## Common JIT Optimization Quick Reference
+
+| Optimization | Benefit | Trigger Condition |
+|---|---|---|
+| Method inlining | 5-10x | Small method + hot |
+| Stack allocation | Reduce GC | Object doesn't escape |
+| Scalar replacement | Object disappears | Object doesn't escape |
+| Lock elision | No lock overhead | Object in synchronized block doesn't escape |
+| Lock coarsening | Reduce lock count | Adjacent synchronized blocks |
+| Loop unrolling | Reduce loop overhead | Small loop |
+| Loop vectorization | SIMD acceleration | Contiguous array access |
+| Branch prediction | Pipeline not broken | Profile data |
+| Virtual method monomorphization | Inlining | Single implementation |
+| Dead code elimination | Remove unexecuted code | Compile-time analysis |
+| Constant folding | Compile-time computation | Operands are constants |
+
+## JDK 17 JIT Features
+
+### Tiered Compilation Enabled by Default
+
+JDK 17 has tiered compilation enabled by default (`-XX:+TieredCompilation`), all 5 tiers active. Don't disable for most scenarios.
+
+**Short-running application exception**:
+- CLI tools, batch jobs may never warm up to tier 4
+- Consider `-XX:TieredStopAtLevel=1` (use only C1)
+- Or GraalVM Native Image (AOT)
+
+### Sealed Class Helps Devirtualization
+
+JDK 17 sealed class knows all implementations at compile time -> JIT monomorphic inlining:
+
+```java
+public sealed interface Shape permits Circle, Rectangle, Triangle {}
+
+// JIT sees Shape actually has only 3 implementations
+// If only Circle is used at runtime -> monomorphic inlining
+// Circle + Rectangle used -> bimorphic (branch + inline)
+```
+
+**Compared to non-sealed**: Non-sealed interfaces theoretically have unlimited implementations -> JIT doesn't dare to aggressively inline.
+
+### Pattern Matching Compilation Optimization
+
+JDK 17 pattern matching for switch (preview), compiled to `tableswitch`:
+
+```java
+switch (shape) {
+    case Circle c -> ...;       // Compiled to jump table, no instanceof chain
+    case Rectangle r -> ...;
+    case Triangle t -> ...;
+}
+```
+
+Faster than `if instanceof + cast` chain (multiple type checks -> 1).
+
+### Vector API (incubator)
+
+JDK 17 incubator (`--add-modules jdk.incubator.vector`), explicit SIMD:
+
+```java
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorSpecies;
+
+static final VectorSpecies<Float> SPECIES = FloatVector.SPECIES_256;
+
+void vectorAdd(float[] a, float[] b, float[] c) {
+    int i = 0;
+    int upper = SPECIES.loopBound(a.length);
+    for (; i < upper; i += SPECIES.length()) {
+        FloatVector va = FloatVector.fromArray(SPECIES, a, i);
+        FloatVector vb = FloatVector.fromArray(SPECIES, b, i);
+        va.add(vb).intoArray(c, i);
+    }
+    for (; i < a.length; i++) c[i] = a[i] + b[i];
+}
+```
+
+**Compared to C2 auto-vectorization**:
+- C2 auto: Depends on JIT judgment, unstable (code change may disable vectorization)
+- Vector API: Explicit vectorization, cross-platform guarantee
+
+**JDK 17 status**: Incubator, API may change. JDK 19+ preview.
+
+### Compact Strings (JDK 9+ default)
+
+JDK 9+ String internally uses `byte[]` + coder flag:
+- ASCII strings: Latin-1 encoding, 1 byte/character (JDK 8 was 2 bytes)
+- Non-ASCII: UTF-16, 2 bytes/character
+
+**Benefit**: ASCII string memory halved. Enabled by default in JDK 17, no configuration needed.
+
+### CDS / AppCDS
+
+Class Data Sharing, startup acceleration:
+
+```bash
+# JDK 17: Generate default CDS archive
+java -Xshare:dump
+
+# Use at runtime
+java -Xshare:on -jar app.jar
+
+# AppCDS (custom classes)
+java -XX:DumpLoadedClassList=classes.lst -jar app.jar
+java -Xshare:dump -XX:SharedClassList=classes.lst -XX:SharedArchiveFile=app.jsa -jar app.jar
+java -Xshare:on -XX:SharedArchiveFile=app.jsa -jar app.jar
+```
+
+**Benefit**: Startup time reduced 30-50%, memory usage lowered (multiple processes share metadata).
+
+## Anti-patterns
+
+- Short-running application tuning `-XX:+TieredCompilation` expecting warmup optimization -> JIT may not take effect, actually slower
+- Code Cache set too small -> deoptimization
+- Complex inheritance hierarchies on hot paths -> virtual method polymorphism, no inlining
+- Heavy reflection -> JIT has difficulty optimizing
+- Lambda capturing variables on hot path -> creates Lambda object each time
+- JDK 17 waiting for C2 auto-vectorization -> unstable, use Vector API on critical paths
+- JDK 17 using Lombok @Data -> Records are compiler-generated, no reflection
+- JDK 17 `instanceof` chain + cast -> sealed + pattern matching
+- JDK 17 reflective access to non-exported packages without `--add-opens` -> `InaccessibleObjectException`
+
+## Reference Documentation
+
+- OpenJDK HotSpot documentation: `https://openjdk.org/groups/hotspot/`
+- JIT Watcher (JIT visualization): `https://github.com/AdoptOpenJDK/jitwatch`
+- GraalVM: `https://www.graalvm.org/`
+- Project Leyden (AOT evolution): `https://openjdk.org/projects/leyden/`

--- a/.claude/skills/performance-tuning/references/jmh_profiling.md
+++ b/.claude/skills/performance-tuning/references/jmh_profiling.md
@@ -1,0 +1,585 @@
+# JMH and Profiling Tools
+
+This file supplements SKILL.md's performance testing section, providing in-depth coverage of JMH API, pitfalls, Profiling tool comparison, and flame graphs. Read on demand when users ask "how to measure performance" or "what tool to use for locating bottlenecks".
+
+## JMH (Java Microbenchmark Harness)
+
+OpenJDK's Java microbenchmark framework, the only trustworthy Java microbenchmark tool. Hand-written `System.currentTimeMillis()` measurements are inaccurate -- JIT optimization, warmup, and dead code elimination all distort results.
+
+### Maven Dependency
+
+```xml
+<dependency>
+    <groupId>org.openjdk.jmh</groupId>
+    <artifactId>jmh-core</artifactId>
+    <version>1.37</version>
+</dependency>
+<dependency>
+    <groupId>org.openjdk.jmh</groupId>
+    <artifactId>jmh-generator-annprocess</artifactId>
+    <version>1.37</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+### JMH Annotations
+
+| Annotation | Purpose | Common Values |
+|---|---|---|
+| `@Benchmark` | Mark benchmark method | - |
+| `@BenchmarkMode` | What to measure | `Mode.Throughput` / `Mode.AverageTime` / `Mode.SampleTime` |
+| `@OutputTimeUnit` | Time unit | `TimeUnit.MILLISECONDS` / `TimeUnit.NANOSECONDS` |
+| `@Warmup` | Warmup | `iterations=5, time=1` |
+| `@Measurement` | Formal measurement | `iterations=5, time=1` |
+| `@Fork` | JVM process count | `2` (required, isolates JIT) |
+| `@State` | State scope | `Scope.Thread` / `Scope.Benchmark` / `Scope.Group` |
+| `@Param` | Parameterization | `{"100", "1000", "10000"}` |
+| `@Setup` | Initialization | `Level.Trial` / `Level.Invocation` / `Level.Iteration` |
+| `@TearDown` | Cleanup | Same as above |
+| `@CompilerControl` | Control JIT | `CompilerControl.Mode.DONT_INLINE` |
+
+### Basic Example
+
+```java
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class ListBenchmark {
+
+    @Param({"100", "1000", "10000"})
+    int size;
+
+    List<Integer> list;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        list = IntStream.range(0, size).boxed().collect(Collectors.toList());
+    }
+
+    @Benchmark
+    public int forEachSum() {
+        int sum = 0;
+        for (int x : list) sum += x;
+        return sum;
+    }
+
+    @Benchmark
+    public int streamSum() {
+        return list.stream().mapToInt(Integer::intValue).sum();
+    }
+
+    @Benchmark
+    public int parallelStreamSum() {
+        return list.parallelStream().mapToInt(Integer::intValue).sum();
+    }
+
+    public static void main(String[] args) throws Exception {
+        org.openjdk.jmh.Main.main(args);
+    }
+}
+```
+
+Run: `mvn clean install && java -jar target/benchmarks.jar`
+
+### JMH API Advanced
+
+#### Blackhole (Avoid Dead Code Elimination)
+
+JIT eliminates code whose results are unused. JMH provides `Blackhole` to consume results:
+
+```java
+@Benchmark
+public void consumeResult(Blackhole bh) {
+    bh.consume(list.size());
+    bh.consume(list.get(0));
+}
+```
+
+#### @State State Objects
+
+State objects are shared between benchmark methods:
+
+```java
+@State(Scope.Thread)
+public static class MyState {
+    public int x;
+    public List<Integer> list;
+
+    @Setup
+    public void setup() {
+        list = IntStream.range(0, 1000).boxed().collect(Collectors.toList());
+    }
+}
+
+@Benchmark
+public int benchmark(MyState state) {
+    return state.list.get(state.x);
+}
+```
+
+#### @Param Parameterization
+
+```java
+@Param({"100", "1000", "10000", "100000"})
+public int size;
+
+@Param({"true", "false"})
+public boolean useParallel;
+```
+
+JMH runs all combinations.
+
+#### @CompilerControl Control Inlining
+
+```java
+@Benchmark
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+public int noInline() { ... }
+```
+
+Use for debugging "performance difference before/after inlining".
+
+### JMH Pitfalls
+
+#### 1. Not Using @Fork
+
+```java
+// Wrong: single process, JIT state pollution
+@Fork(0)  // or no @Fork
+```
+
+Correct: `@Fork(2)` minimum.
+
+#### 2. Insufficient @Warmup
+
+```java
+// Wrong: insufficient warmup, JIT not fully effective
+@Warmup(iterations = 1, time = 1)
+```
+
+Correct: `@Warmup(iterations = 5, time = 1)` minimum.
+
+#### 3. new Objects Inside Benchmark Method
+
+```java
+// Wrong: measuring allocation
+@Benchmark
+public List<Integer> createList() {
+    return new ArrayList<>();
+}
+```
+
+Should: Prepare in `@Setup`, benchmark only measures core logic.
+
+#### 4. Dead Code Elimination
+
+```java
+// Wrong: return value unused, JIT may eliminate entire method
+@Benchmark
+public void compute() {
+    int x = 1 + 2 + 3;
+}
+```
+
+Should: `return x` or use `Blackhole`.
+
+#### 5. Loop Inside Benchmark
+
+```java
+// Wrong: JMH loops itself, you don't need to loop
+@Benchmark
+public void loop() {
+    for (int i = 0; i < 1000; i++) { ... }
+}
+```
+
+Should: Single operation; JMH calls based on `time`.
+
+#### 6. Inconsistent Warmup
+
+Short warmup measures C1-compiled version, formal run measures C2-compiled version. Ensure `@Warmup` + `@Fork` provide sufficient warmup for each fork.
+
+#### 7. JDK 17 Module System Reflection
+
+JMH benchmarks use reflection to load `@Benchmark` methods. Accessing fields in non-exported packages requires `--add-opens`.
+
+```java
+// JVM parameters
+--add-opens java.base/java.lang=ALL-UNNAMED
+--add-opens java.base/java.util=ALL-UNNAMED
+```
+
+Pass via `jvmArgsAppend` at JMH startup:
+```java
+@Fork(jvmArgsAppend = {"--add-opens", "java.base/java.lang=ALL-UNNAMED"})
+```
+
+#### 8. JDK 17 Vector API Benchmark
+
+Vector API is incubator; benchmark requires `--add-modules jdk.incubator.vector`:
+
+```java
+@Fork(jvmArgsAppend = {"--add-modules", "jdk.incubator.vector"})
+```
+
+### JMH Output Interpretation
+
+```
+Benchmark                          (size)   Mode  Cnt     Score    Error  Units
+ListBenchmark.forEachSum               100  thrpt    10  1234.567 +/- 12.345  ops/ms
+ListBenchmark.streamSum               100  thrpt    10   987.654 +/- 10.123  ops/ms
+```
+
+- **Score**: Throughput (ops/ms = operations per millisecond) or average time
+- **Error**: 99% confidence interval
+- **Cnt**: Measurement iterations
+
+### JMH Profiler
+
+JMH built-in profilers:
+
+```bash
+# GC situation
+-prof gc
+
+# Memory allocation
+-prof gc -gc true
+
+# Stack sampling
+-prof stack
+
+# Linux perf (system-level)
+-prof perf
+
+# Class loading
+-prof cl
+```
+
+Usage: `java -jar target/benchmarks.jar -prof gc`
+
+## Profiling Tool Comparison
+
+| Tool | Granularity | Overhead | Output | Scenario |
+|---|---|---|---|---|
+| **JFR** (JDK Flight Recorder) | System-level + method-level | Very low (< 1%) | Binary .jfr | Production long-running, global view |
+| **async-profiler** | Method-level CPU/Alloc/Lock | Low | Flame graph | Continuous sampling, hotspot location |
+| **JProfiler / YourKit** | Full-featured GUI | Medium | GUI | Local deep tuning |
+| **VisualVM** | Overview | Medium | GUI | Local quick view |
+| **JMH** | Method-level precise | High | Text | Microbenchmark |
+| **Arthas** | Online diagnosis | Medium | CLI | Production dynamic trace |
+| **BTrace** | Online scripting | Medium | Custom | Production dynamic instrumentation |
+
+## JFR (JDK Flight Recorder)
+
+Open-sourced since JDK 11, production-ready. Overhead < 1%, the **preferred** long-term sampling tool for production environments.
+
+### Start JFR Recording
+
+```bash
+# Start 30-second recording
+jcmd <pid> JFR.start duration=30s filename=/tmp/recording.jfr
+
+# Continuous recording (background)
+jcmd <pid> JFR.start filename=/tmp/cont.jfr maxage=1h maxsize=100M
+
+# View running recordings
+jcmd <pid> JFR.check
+
+# Stop
+jcmd <pid> JFR.stop name=1
+```
+
+### Analyze JFR
+
+- **JDK Mission Control (JMC)**: Official GUI, download from `https://github.com/openjdk/jmc`
+- Command-line tool: `jfr print --events cpuload recording.jfr`
+
+### JFR Key Event Types
+
+- `jdk.CPULoad`: CPU load
+- `jdk.JavaMonitorWait` / `jdk.JavaMonitorEnter`: Lock wait
+- `jdk.GarbageCollection`: GC
+- `jdk.ObjectAllocationSample`: Allocation sampling
+- `jdk.ExecutionSample`: Method stack sampling (source for flame graphs)
+
+### JDK 17 JFR Enhancements
+
+**Streaming API (JDK 14+)**: Real-time streaming JFR events without disk persistence:
+
+```java
+import jdk.jfr.consumer.EventStream;
+
+try (var stream = EventStream.openRepository()) {
+    stream.onEvent("jdk.GarbageCollection", e -> {
+        System.out.println("GC: " + e.getDuration("duration"));
+    });
+    stream.startAsync();
+    Thread.sleep(60_000);
+}
+```
+
+**Application scenarios**:
+- Application-embedded JFR consumption -> real-time monitoring and alerting
+- Custom dashboards without external tool dependencies
+- APM vendor integration
+
+**JDK 17 JFR advantages**:
+- Overhead < 1%, can be kept on in production long-term
+- `settings=profile` provides more complete events than `settings=default`
+- Commonly enabled at startup: `-XX:StartFlightRecording=...`
+- Key event upgrade: `jdk.ObjectAllocationSample` (JDK 14+) replaces old allocation sampling
+
+**JDK 17 JFR startup configuration recommendation**:
+```
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=1h,maxsize=100M,settings=profile
+-XX:FlightRecorderOptions=stackdepth=64
+```
+- `maxage=1h maxsize=100M`: Rolling, 1 hour or 100MB
+- `settings=profile`: High sampling rate (vs `default`)
+- `stackdepth=64`: Stack depth (default 64, can increase to 128 for complex applications)
+
+## async-profiler
+
+Open source, low-overhead sampling, outputs flame graphs. **Production-ready**.
+
+### Installation
+
+```bash
+# Download
+wget https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz
+tar xzf async-profiler-3.0-linux-x64.tar.gz
+
+# macOS use .dmg package
+```
+
+### CPU Flame Graph
+
+```bash
+# 30-second CPU sampling
+./profiler.sh -d 30 -f flame.html <pid>
+
+# View which method consumes the most CPU in the SVG flame graph
+```
+
+### Allocation Flame Graph
+
+```bash
+# 30-second allocation sampling
+./profiler.sh -d 30 -e alloc -f alloc.html <pid>
+
+# Find memory allocation hotspots (high-frequency new objects)
+```
+
+### Lock Flame Graph
+
+```bash
+./profiler.sh -d 30 -e lock -f lock.html <pid>
+```
+
+### Attach at Java Startup
+
+```bash
+# Mount at JVM startup
+java -agentpath:/path/libasyncProfiler.so=start,event=cpu,file=flame.html -jar app.jar
+```
+
+### How to Read Flame Graphs
+
+- X-axis: Method call stack spread out
+- Y-axis: Stack depth (top is callee, bottom is main)
+- Width: CPU time proportion
+- Wider = more worth optimizing
+
+**Finding bottlenecks**: Look for the widest "plateau" -- a single method with the highest CPU proportion.
+
+## Arthas
+
+Alibaba's online diagnostic tool, production-ready.
+
+### Installation and Startup
+
+```bash
+# Download
+curl -O https://arthas.aliyun.com/arthas-boot.jar
+
+# Start (attach to specified PID)
+java -jar arthas-boot.jar <pid>
+```
+
+### Common Commands
+
+```bash
+# Method call timing (find slow methods)
+trace com.example.MyService doSomething
+
+# Decompile (view JIT-compiled bytecode)
+jad com.example.MyService
+
+# Method input/output parameters
+watch com.example.MyService doSomething '{params, returnObj}' -x 2
+
+# Method call path
+stack com.example.MyService doSomething
+
+# View thread usage
+thread -n 3
+
+# View JVM information
+dashboard
+jvm
+
+# View which method is creating objects
+profiler start --event alloc
+profiler stop --format flame
+```
+
+## VisualVM
+
+Local tuning tool, view real-time overview. Not suitable for production.
+
+### Main Features
+
+- Overview: CPU / heap / threads / classes
+- Memory: Heap histogram, GC activity
+- Threads: Thread state, deadlock detection
+- CPU Profiler: Method-level sampling (high overhead)
+- Memory Profiler: Allocation sampling
+
+### Usage
+
+```bash
+jvisualvm  # Bundled with JDK 8
+
+# JDK 9+ download separately
+# https://visualvm.github.io/
+```
+
+## JProfiler / YourKit
+
+Commercial tools for local deep tuning. More features, but require payment.
+
+**When to use**:
+- Complex memory leak analysis
+- Interactive SQL query analysis needed
+- Deep method-level Profiling needed
+
+**Not for production**: High overhead, impacts performance.
+
+## Performance Metrics System
+
+### Core Metrics
+
+| Metric | Meaning | Calculation |
+|---|---|---|
+| **Throughput** (QPS/TPS) | Requests processed per second | Total requests / total time |
+| **Average latency** | Average request time | Total time / request count |
+| **P50** | Median latency | 50th percentile after sorting |
+| **P90** | 90% request time | 90th percentile after sorting |
+| **P99** | 99% request time | 99th percentile after sorting |
+| **P999** | 99.9% request time | 99.9th percentile after sorting |
+| **GC throughput** | GC time proportion | Total GC time / total time |
+| **GC pause time** | STW duration | Individual GC pauses |
+
+### Metric Pitfalls
+
+**Only looking at average latency**: Masked by long tail.
+- Average 50ms, but possibly 99% of users < 10ms, 1% of users 5 seconds
+- Look at P99 / P999 for realistic experience
+
+**Only looking at throughput**: May rely on request queuing.
+- High QPS but request backlog -> average latency spikes
+- Must be viewed together with latency
+
+**Only measuring once**: Not trustworthy.
+- Use statistically significant multiple measurements (JMH default 5+5)
+- Look at +/- Error confidence interval
+
+### Latency vs Throughput
+
+- **Throughput first**: Batch processing, ETL, offline computation
+- **Latency first**: Real-time services, user interaction, financial trading
+- **Balance both**: Usually constrained by SLA (e.g., P99 < 100ms)
+
+## Performance Testing Methodology
+
+### Pre-Test Confirmation
+
+- What to measure? (Throughput / latency / memory allocation)
+- What tool to use? (JMH / Profiling / integration testing)
+- Which environment to test in? (Local / staging / production)
+- What is the baseline? (Performance of unoptimized version)
+
+### During-Test Guarantees
+
+- **Isolation**: `@Fork` isolates JVM, avoids JIT state pollution
+- **Sufficient warmup**: `@Warmup` lets JIT compilation complete
+- **Multiple measurements**: 5+ iterations, look at confidence interval
+- **Control variables**: Change only one variable at a time
+
+### Post-Test Verification
+
+- Compare against baseline: Same metric before/after optimization
+- Significance: Is the difference outside the confidence interval
+- Production validation: Microbenchmark results may not represent real load
+
+## Practical Profiling Workflow
+
+### 1. Locate CPU Bottleneck
+
+```bash
+# JFR 30-second sampling
+jcmd <pid> JFR.start duration=30s filename=/tmp/cpu.jfr
+
+# Or async-profiler
+./profiler.sh -d 30 -f flame.html <pid>
+
+# View flame graph in JMC, find widest method
+```
+
+### 2. Locate Allocation Hotspot
+
+```bash
+./profiler.sh -d 30 -e alloc -f alloc.html <pid>
+
+# Or JFR: Add -XX:StartFlightRecording=filename=/tmp/alloc.jfr,settings=profile at JFR startup
+```
+
+Find methods with high-frequency `new`.
+
+### 3. Locate Lock Wait
+
+```bash
+./profiler.sh -d 30 -e lock -f lock.html <pid>
+
+# Or JFR: View jdk.JavaMonitorWait events
+```
+
+### 4. Locate Frequent GC
+
+```bash
+# JFR: View jdk.GarbageCollection events
+```
+
+**jstat / jcmd real-time GC diagnosis**: Belongs to jvm-troubleshoot skill, see `../../jvm-troubleshoot/references/diagnostic_commands.md` and `gc_tuning_guide.md`.
+
+### 5. Online Trace
+
+```bash
+# Arthas trace
+trace com.example.MyService doSomething
+
+# Find slowest method stack
+```
+
+## Reference Documentation
+
+- JMH official: `https://openjdk.org/projects/code-tools/jmh/`
+- JMH samples: `https://github.com/openjdk/jmh/tree/main/jmh-samples/src/main/java/org/openjdk/jmh/samples`
+- async-profiler: `https://github.com/async-profiler/async-profiler`
+- JFR / JMC: `https://github.com/openjdk/jmc`
+- Arthas: `https://arthas.aliyun.com/`
+- VisualVM: `https://visualvm.github.io/`
+- Flame graph principles (Brendan Gregg): `https://www.brendangregg.com/flamegraphs.html`

--- a/.claude/skills/performance-tuning/references/jvm_params.md
+++ b/.claude/skills/performance-tuning/references/jvm_params.md
@@ -1,0 +1,325 @@
+# JVM Parameter Details (JDK 17 baseline)
+
+This file supplements SKILL.md's JVM parameter tuning content, **using JDK 17 as the baseline**. Explains the value ranges, defaults, and scenarios for heap/stack/Metaspace/CodeCache/JIT parameters. Read on demand when users ask "what value should this parameter be set to" or "what does this parameter do".
+
+## JDK 17 Default Parameter Table
+
+JDK 17 key default values (no need to change for most scenarios):
+
+| Parameter | JDK 17 Default | Notes |
+|---|---|---|
+| `-XX:+UseG1GC` | Yes | Default collector |
+| `-XX:+TieredCompilation` | Yes | Tiered compilation |
+| `-XX:+DoEscapeAnalysis` | Yes | Escape analysis |
+| `-XX:+UseContainerSupport` | Yes | Auto-detect cgroup in containers |
+| `-XX:MaxGCPauseMillis` | 200 | G1 target pause |
+| `-XX:ReservedCodeCacheSize` | 240M | JIT code cache |
+| `-XX:MetaspaceSize` | 20M (Linux) | Full GC trigger threshold |
+| `-XX:MaxMetaspaceSize` | No upper limit | Limited by physical memory |
+| `-XX:CompileThreshold` | 10000 | C2 compilation threshold (adaptive under tiered compilation) |
+| `-XX:MaxInlineSize` | 35 | Regular method inlining upper limit |
+| `-XX:FreqInlineSize` | 325 | Hot method inlining upper limit |
+| `-XX:SurvivorRatio` | 8 | Eden:Survivor |
+| `-XX:TargetSurvivorRatio` | 50 | Survivor occupancy target |
+| `-XX:MaxTenuringThreshold` | 15 | Age for promotion to old generation |
+
+**View actual values for this process**:
+```bash
+jcmd <pid> VM.flags
+# Or print at startup
+java -XX:+PrintFlagsFinal -version | grep <param>
+```
+
+## Parameter Classification
+
+JVM parameters fall into 3 categories:
+- **Standard parameters** (`-`): Supported by all JVM implementations, e.g., `-version`, `-jar`
+- **Non-standard parameters** (`-X`): HotSpot default implementation, e.g., `-Xmx`, `-Xms`
+- **Unstable parameters** (`-XX`): HotSpot-specific, may change between versions, e.g., `-XX:+UseG1GC`
+
+**Boolean -XX**: `-XX:+OptionName` enables, `-XX:-OptionName` disables.
+**Numeric -XX**: `-XX:OptionName=value`, value can have units (k/m/g).
+
+## Heap-Related Parameters
+
+### -Xms / -Xmx
+
+| Parameter | Meaning | JDK 17 Default |
+|---|---|---|
+| `-Xms` | Initial heap | Container: cgroup memory / 4; Physical machine: physical memory / 64 |
+| `-Xmx` | Maximum heap | Container: cgroup memory / 4; Physical machine: physical memory / 4 |
+
+**Value suggestions**:
+- Production services: `-Xms = -Xmx`, avoid heap dynamic expansion triggering Full GC
+- Container: `-XX:+UseContainerSupport` (enabled by default in JDK 17), auto-detects cgroup memory limits
+- Using percentages is more convenient: `-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=75.0`
+- Heap upper limit: **<= 32GB**, exceeding disables compressed oops (`-XX:+UseCompressedOops`), object references become 8 bytes, actually consuming more memory
+- Inside containers: Allocate 50-75% of container memory to heap, rest for Metaspace/thread stacks/direct memory/JVM itself
+
+### -Xmn / -XX:NewRatio / -XX:SurvivorRatio
+
+| Parameter | Meaning | Default |
+|---|---|---|
+| `-Xmn` | Young generation size | Platform-dependent |
+| `-XX:NewRatio=N` | Old:Young = N:1 (NewRatio=2 means young generation = 1/3 of heap) | 2 |
+| `-XX:SurvivorRatio=N` | Eden:Survivor = N:1 | 8 |
+| `-XX:MaxTenuringThreshold=N` | Object age for promotion to old generation | 15 |
+
+**When using G1** (JDK 17 default):
+- Don't manually set `-Xmn` / `-XX:NewRatio` -- G1 adaptively adjusts
+- Can set `-XX:G1HeapRegionSize=8m`, auto-selected based on heap size (1MB-32MB)
+
+**When using Parallel/SerialGC**:
+- `-XX:NewRatio=2`: Young generation 1/3, old generation 2/3
+- `-XX:SurvivorRatio=8`: Eden 80%, each Survivor 10%
+- Larger young generation -> fewer Young GC but longer each time; smaller young generation -> more frequent Young GC but shorter each time
+
+### -XX:PretenureSizeThreshold
+
+Large objects exceeding this value go directly to old generation, avoiding back-and-forth copying in young generation.
+
+- Unit: bytes
+- Default: 0 (no limit, JVM decides)
+- When using G1: Large objects (> half of region) go to humongous region, no need to adjust this parameter
+- Increasing reduces large object copying in young generation, but too large causes old generation to fill up quickly
+
+**Scenario**: Cached large objects, large arrays, large strings should go to old generation.
+
+## Metaspace Parameters
+
+| Parameter | Meaning | JDK 17 Default |
+|---|---|---|
+| `-XX:MetaspaceSize` | Full GC trigger threshold | 20M (Linux) |
+| `-XX:MaxMetaspaceSize` | Metaspace upper limit | No upper limit (limited by physical memory) |
+
+**Suggestions**:
+- Production fixed: `-XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=512m`, avoid runtime expansion triggering Full GC
+- Many dynamically generated classes (CGLIB/ByteBuddy): Increase MaxMetaspaceSize
+- MetaspaceSize is not initial allocation, it's the GC trigger threshold -- the point of the first Full GC
+
+**OOM Metaspace troubleshooting**: View `jmap -clstats <pid>` ClassLoader count. See jvm-troubleshoot SKILL.md for details.
+
+## Stack Parameters
+
+### -Xss
+
+Per-thread call stack size.
+
+| Platform | JDK 17 Default |
+|---|---|
+| Linux x64 | 1M |
+| Windows x64 | 1M |
+| macOS x64 | 1M |
+| Linux ARM64 | 2M |
+
+**Tuning scenarios**:
+- Deep recursion: Increase to 2M-4M, prevent StackOverflowError
+- Very many threads (thousands): Decrease to 256K, save memory
+- Default: Don't change
+
+**Calculation**: 1000 threads x 1M = 1GB stack memory; stack memory is significant with many threads.
+
+## Code Cache
+
+| Parameter | Meaning | JDK 17 Default |
+|---|---|---|
+| `-XX:ReservedCodeCacheSize` | JIT code cache upper limit | 240M |
+| `-XX:InitialCodeCacheSize` | Initial code cache | 160K |
+| `-XX:CodeCacheExpansionSize` | Expansion step | 64K |
+
+**Notes**:
+- Too small -> JIT-compiled methods are discarded back to interpreted execution (deoptimization), performance drops sharply
+- JDK 17 default 240M is sufficient for most cases; large applications (100k+ classes) can increase to 512M
+- View: `jcmd <pid> Compiler.CodeCache`
+
+## JIT Parameters
+
+### -XX:+TieredCompilation
+
+Tiered compilation switch, enabled by default in JDK 17.
+
+**Impact of disabling**:
+- Only C2 compilation used, method compilation threshold increases (10x+), slow warmup
+- Short-running applications may benefit (no profiling overhead)
+- Long-running applications **should not disable**
+
+### -XX:CompileThreshold
+
+Method invocation count reaches threshold to trigger compilation. Adaptive under tiered compilation mode, no longer fixed.
+
+| Mode | Threshold | Value | Description |
+|---|---|---|
+| C1 | ~1500 (adaptive) | Triggers C1 compilation |
+| C2 | ~10000 (adaptive) | Triggers C2 compilation |
+
+### -XX:+PrintCompilation
+
+Print JIT compilation log for debugging JIT behavior.
+
+```bash
+jcmd <pid> Compiler.directives_print
+# Or add at startup
+-XX:+PrintCompilation -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining
+```
+
+See `jit_compiler.md` for more JIT details.
+
+## GC Parameters
+
+**JDK 17 default G1**. Commonly used:
+```
+-XX:+UseG1GC                          # Default, writing it out is clearer
+-XX:+UseZGC                           # JDK 15+ production-ready
+-XX:+UseShenandoahGC                  # JDK 15+ stable (OpenJDK build)
+-XX:+UseParallelGC                    # Throughput first
+-XX:MaxGCPauseMillis=200              # Target pause time (G1/ZGC)
+-XX:G1HeapRegionSize=8m               # G1 region size
+-XX:ParallelGCThreads=N               # GC thread count
+-XX:ConcGCThreads=N                   # Concurrent GC thread count
+-XX:InitiatingHeapOccupancyPercent=45 # G1 heap occupancy to trigger concurrent marking
+-XX:G1NewSizePercent=5                 # G1 young generation lower bound
+-XX:G1MaxNewSizePercent=60             # G1 young generation upper bound
+-XX:+DisableExplicitGC                # Disable System.gc()
+-XX:+ExplicitGCInvokesConcurrent      # System.gc() goes concurrent (G1)
+-XX:+AlwaysPreTouch                    # Pre-touch all heap pages at startup
+```
+
+**ZGC key parameters** (JDK 17 is **non-generational version**, generational ZGC is stable in JDK 21+):
+```
+-XX:ZAllocationSpikeTolerance=2       # Allocation spike tolerance
+-XX:ConcGCThreads=N                   # Concurrent GC thread count (default ParallelGCThreads * 1/4)
+```
+
+**Shenandoah key parameters**:
+```
+-XX:ShenandoahGCHeuristics=adaptive   # Adaptive (default)
+-XX:ShenandoahGCHeuristics=aggressive # Aggressive (low latency)
+-XX:ShenandoahGCHeuristics=compact     # Compact (save memory)
+```
+
+See `gc_tuning.md` for more GC tuning details.
+
+## Monitoring Parameters
+
+**Commonly enabled in production** (JDK 17 unified logging syntax):
+```
+-Xlog:gc*:file=gc.log:time,uptime:filecount=10,filesize=10M   # GC log
+-XX:+HeapDumpOnOutOfMemoryError                                # Auto dump on OOM
+-XX:HeapDumpPath=/var/log/dumps/                              # dump path
+-XX:ErrorFile=/var/log/hs_err_%p.log                           # Fatal error log
+```
+
+**JDK 17 JFR recommended always on** (overhead < 1%):
+```
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=1h,maxsize=100M,settings=profile
+-XX:FlightRecorderOptions=stackdepth=64
+```
+
+## Debug Parameters
+
+**Must unlock first**:
+```
+-XX:+UnlockDiagnosticVMOptions     # Unlock diagnostic parameters
+-XX:+PrintFlagsFinal               # Print all JVM parameter final values
+-XX:+PrintFlagsInitial            # Print default values
+-XX:+PrintCommandLineFlags         # Print parameters set at startup
+-XX:+PrintInlining                 # Print inlining decisions
+-XX:+PrintCompilation              # Print JIT compilation log
+-XX:+LogCompilation                # Detailed compilation log (requires PrintCompilation)
+```
+
+**View JVM parameters**:
+```bash
+# View after process starts
+jcmd <pid> VM.flags
+
+# All parameter final values
+java -XX:+PrintFlagsFinal -version | grep -i heapsize
+```
+
+## Module System Parameters (JDK 17 Must-Know)
+
+JDK 9+ module system; reflective access to non-exported packages must be explicitly opened:
+
+```
+--add-opens java.base/java.lang=ALL-UNNAMED            # Reflective access to String internals
+--add-opens java.base/java.util=ALL-UNNAMED            # Reflective access to collection internals
+--add-opens java.base/java.nio=ALL-UNNAMED             # Reflective access to NIO
+--add-exports java.base/sun.nio.ch=ALL-UNNAMED         # Direct access (non-reflective)
+```
+
+**Typical scenarios**:
+- Using Spring / Hibernate / ByteBuddy reflection -> need `--add-opens`
+- Using Netty to access NIO internals -> need `--add-opens java.base/java.nio`
+- Using Reflect.setField to access private -> need `--add-opens`
+
+**Error keyword**: `InaccessibleObjectException` -> missing `--add-opens`.
+
+## Practical Parameter Combinations
+
+### Microservice (JDK 17, Container)
+
+```
+-XX:+UseContainerSupport
+-XX:InitialRAMPercentage=50.0
+-XX:MaxRAMPercentage=75.0
+-XX:+UseG1GC
+-XX:MaxGCPauseMillis=200
+-XX:MetaspaceSize=256m
+-XX:MaxMetaspaceSize=512m
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath=/var/log/dumps/
+-Xlog:gc*:file=/var/log/gc.log:time,uptime:filecount=10,filesize=10M
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=1h,maxsize=100M,settings=profile
+-XX:+AlwaysPreTouch
+-XX:+DisableExplicitGC
+```
+
+### High Throughput Batch Processing (JDK 17, Physical Machine)
+
+```
+-Xms16g -Xmx16g
+-XX:+UseParallelGC
+-XX:ParallelGCThreads=16
+-XX:+AggressiveHeap
+-XX:+UseParallelOldGC
+-XX:ReservedCodeCacheSize=512m
+-XX:+TieredCompilation
+```
+
+### Low-Latency Large Application (JDK 17, Physical Machine or Large Container)
+
+```
+-Xms32g -Xmx32g
+-XX:+UseZGC                          # JDK 17 non-generational ZGC, sub-millisecond pause
+-XX:ZAllocationSpikeTolerance=2
+-XX:ConcGCThreads=8
+-XX:MetaspaceSize=512m
+-XX:MaxMetaspaceSize=1g
+-XX:ReservedCodeCacheSize=512m
+-XX:+HeapDumpOnOutOfMemoryError
+-Xlog:gc*:file=/var/log/gc.log:time,uptime:filecount=20,filesize=50M
+```
+
+Note: JDK 17 ZGC is non-generational; throughput under large heap is slightly lower than generational version (JDK 21+). If heap > 32GB and throughput-sensitive, consider upgrading to JDK 21 for generational ZGC.
+
+### CLI / Short-Running Application (JDK 17)
+
+```
+-XX:+TieredCompilation
+-XX:ReservedCodeCacheSize=128m
+# Or use GraalVM Native Image for ahead-of-time compilation (JDK 17 production-ready)
+```
+
+**Note**: CLI applications have insufficient warmup; JIT may never take effect. Consider:
+- CDS (Class Data Sharing): `-Xshare:on`
+- GraalVM Native Image: AOT compilation
+- AppCDS: CDS for custom classes
+
+## Reference Documentation
+
+- Oracle JDK 17 JVM parameters: `https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html`
+- OpenJDK 17 source: `https://github.com/openjdk/jdk17`
+- In-project GC tuning: `gc_tuning.md`
+- In-project JIT tuning: `jit_compiler.md`
+- In-project reactive troubleshooting: `../../jvm-troubleshoot/references/gc_tuning_guide.md`

--- a/.claude/skills/performance-tuning/references/tuning_cases.md
+++ b/.claude/skills/performance-tuning/references/tuning_cases.md
@@ -1,0 +1,550 @@
+# Performance Tuning Real-World Cases
+
+This file supplements SKILL.md's practical content, providing 6 end-to-end optimization cases, aligned with jvm-troubleshoot's troubleshooting_cases.md. Read on demand when users ask "how to optimize" or need a reference for a complete tuning workflow.
+
+Each case follows the "problem -> measure baseline -> locate -> optimize -> verify" workflow.
+
+## Case 1: Stream to for Loop
+
+### Problem
+
+Log parsing service processes 100k records/second, CPU consistently at 70%, needs to drop below 50%.
+
+Code example:
+```java
+public int sum(List<Integer> values) {
+    return values.stream()
+        .filter(v -> v > 0)
+        .mapToInt(Integer::intValue)
+        .sum();
+}
+```
+
+### Measure Baseline (JMH)
+
+```java
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class StreamBenchmark {
+
+    @Param({"100", "1000", "10000"})
+    int size;
+
+    List<Integer> list;
+
+    @Setup
+    public void setup() {
+        list = IntStream.range(0, size).boxed().collect(Collectors.toList());
+    }
+
+    @Benchmark
+    public int stream() {
+        return list.stream()
+            .filter(v -> v > 0)
+            .mapToInt(Integer::intValue)
+            .sum();
+    }
+
+    @Benchmark
+    public int forLoop() {
+        int sum = 0;
+        for (int v : list) {
+            if (v > 0) sum += v;
+        }
+        return sum;
+    }
+}
+```
+
+### Results (Example)
+
+```
+Benchmark                      (size)   Mode  Cnt     Score   Error  Units
+StreamBenchmark.stream             100  thrpt    10    12.345 +/- 0.5  ops/ms
+StreamBenchmark.forLoop            100  thrpt    10    45.678 +/- 1.2  ops/ms  <- 3.7x faster
+StreamBenchmark.stream           10000  thrpt    10     1.234 +/- 0.1  ops/ms
+StreamBenchmark.forLoop          10000  thrpt    10     5.678 +/- 0.3  ops/ms  <- 4.6x faster
+```
+
+### Locate
+
+Reasons Stream is slow:
+1. `stream()` creates Stream object -> overhead
+2. `filter` / `mapToInt` boxing/unboxing -> boxing overhead
+3. Internal Spliterator iteration -> indirect invocation
+
+### Optimize
+
+```java
+// Use for for simple iteration
+public int sum(List<Integer> values) {
+    int sum = 0;
+    for (int v : values) {
+        if (v > 0) sum += v;
+    }
+    return sum;
+}
+```
+
+### Verify
+
+- JMH measurement: for is 3.7-4.6x faster than Stream
+- Production CPU dropped from 70% to 45%
+- Note: for is not always faster; complex chained transforms are more readable with Stream
+
+### Reflection
+
+- Stream is not a performance optimization tool; it's a readability tool
+- Use for for simple iteration, Stream for complex transforms
+- Don't blindly use `parallelStream` -- small collections are actually slower
+
+## Case 2: HashMap Capacity Tuning + Lock to LongAdder
+
+### Problem
+
+Rate limiter counter: 1000 QPS + 200 concurrent threads -> `AtomicInteger` increment has CAS retries on multi-core CPU, throughput bottleneck.
+
+Code:
+```java
+public class RateLimiter {
+    private final AtomicInteger count = new AtomicInteger(0);
+    private final Map<String, Integer> stats = new HashMap<>();
+    private final Object lock = new Object();
+
+    public void increment() {
+        count.incrementAndGet();
+        synchronized(lock) {
+            stats.put("total", count.get());
+        }
+    }
+}
+```
+
+### Measure Baseline (JMH)
+
+```java
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@State(Scope.Group)
+public class CounterBenchmark {
+
+    AtomicInteger atomic = new AtomicInteger();
+    LongAdder adder = new LongAdder();
+
+    @Benchmark
+    @Group("atomic")
+    @GroupThreads(8)
+    public void atomicInc() {
+        atomic.incrementAndGet();
+    }
+
+    @Benchmark
+    @Group("adder")
+    @GroupThreads(8)
+    public void adderInc() {
+        adder.increment();
+    }
+}
+```
+
+### Results
+
+```
+Benchmark                          Mode  Cnt     Score    Error  Units
+CounterBenchmark.atomic              thrpt    10    234.5  +/- 12.3  ops/ms
+CounterBenchmark.adder               thrpt    10   1234.5  +/- 45.6  ops/ms  <- 5.3x faster
+```
+
+### Locate
+
+- `AtomicInteger` CAS retries under high contention -> spin overhead
+- `synchronized + HashMap` coarse lock granularity, limited concurrency
+- `HashMap` default capacity 16 + loadFactor 0.75 -> frequent resizing
+
+### Optimize
+
+```java
+public class RateLimiter {
+    // High-concurrency counting uses LongAdder
+    private final LongAdder count = new LongAdder();
+
+    // High-concurrency map uses ConcurrentHashMap
+    private final ConcurrentHashMap<String, Long> stats = new ConcurrentHashMap<>(64);
+
+    public void increment() {
+        count.increment();
+        stats.compute("total", (k, v) -> v == null ? 1 : v + 1);
+    }
+}
+```
+
+### Further: HashMap Capacity Tuning
+
+```java
+// Original code
+Map<String, Integer> stats = new HashMap<>();  // Default capacity 16
+
+// Known size (e.g., 100 keys) -> specify explicitly
+Map<String, Integer> stats = new HashMap<>(100 / 0.75 + 1);  // Avoid resizing
+```
+
+Or for higher concurrency scenarios:
+```java
+ConcurrentHashMap<String, Long> stats = new ConcurrentHashMap<>(64);
+```
+
+### Verify
+
+- LongAdder vs AtomicInteger: 5.3x faster
+- ConcurrentHashMap vs HashMap + synchronized: 5x+ concurrency
+- HashMap with tuned capacity has no resizing pauses
+
+### Reflection
+
+- `AtomicInteger` suits low contention, `LongAdder` suits high contention
+- `HashMap + synchronized` is a dead end for high concurrency -> `ConcurrentHashMap`
+- HashMap with known size -> explicit capacity, avoid resizing
+
+## Case 3: Reflection to MethodHandle
+
+### Problem
+
+Serialization framework processes 50k objects/second; reflection `Method.invoke` is the bottleneck, CPU at 40%.
+
+Code:
+```java
+public class Serializer {
+    public Object getField(Object obj) throws Exception {
+        Method m = obj.getClass().getMethod("getValue");  // Reflective lookup each time
+        return m.invoke(obj);
+    }
+}
+```
+
+### Measure Baseline (JMH)
+
+```java
+@State(Scope.Thread)
+public class ReflectionBenchmark {
+
+    Method method;
+    MethodHandle mh;
+    Function<MyObject, String> lambda;
+
+    @Setup
+    public void setup() throws Exception {
+        method = MyObject.class.getMethod("getValue");
+        method.setAccessible(true);  // Disable access checks
+
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        mh = lookup.findVirtual(MyObject.class, "getValue",
+            MethodType.methodType(String.class));
+
+        // LambdaMetafactory convert to Function
+        // (Simplified: actual code is more complex, see code_level_optimization.md)
+    }
+
+    @Benchmark
+    public String reflectNoCache() throws Exception {
+        // Anti-pattern: reflective Method lookup each time
+        Method m = obj.getClass().getMethod("getValue");
+        return (String) m.invoke(obj);
+    }
+
+    @Benchmark
+    public String reflectCached() throws Exception {
+        return (String) method.invoke(obj);
+    }
+
+    @Benchmark
+    public String methodHandle() throws Throwable {
+        return (String) mh.invoke(obj);
+    }
+}
+```
+
+### Results
+
+```
+Benchmark                          Mode  Cnt     Score    Error  Units
+ReflectionBenchmark.reflectNoCache    thrpt    10    45.6  +/- 2.3  ops/us
+ReflectionBenchmark.reflectCached      thrpt    10   234.5  +/- 12.3  ops/us  <- 5x
+ReflectionBenchmark.methodHandle       thrpt    10  1234.5  +/- 45.6  ops/us  <- 27x
+```
+
+### Locate
+
+Reasons reflection is slow:
+1. `getMethod` scans method table each time -> large overhead
+2. `invoke` internal parameter checking (unless `setAccessible(true)`)
+3. Boxing/unboxing
+4. JIT has difficulty optimizing (virtual call)
+
+### Optimize
+
+```java
+public class Serializer {
+    private static final MethodHandle MH;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH = lookup.findVirtual(MyObject.class, "getValue",
+                MethodType.methodType(String.class));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Object getField(Object obj) throws Throwable {
+        return MH.invoke(obj);
+    }
+}
+```
+
+**Further** (LambdaMetafactory):
+```java
+// Convert MethodHandle to Lambda, no reflection overhead at runtime
+Function<MyObject, String> getter = (Function<MyObject, String>) LambdaMetafactory.metafactory(
+    lookup, "apply", MethodType.methodType(Function.class),
+    MethodType.methodType(Object.class, Object.class),
+    MH, MethodType.methodType(String.class, MyObject.class)
+).getTarget().invoke();
+
+// Usage: close to direct call
+String val = getter.apply(obj);
+```
+
+### Verify
+
+- Cached Method reflection: 5x speedup
+- MethodHandle: 27x speedup (vs uncached)
+- LambdaMetafactory: close to direct call
+
+### Reflection
+
+- Reflection must cache Method/Field
+- MethodHandle is 5-10x faster than `Method.invoke`
+- LambdaMetafactory is close to direct call
+- Large frameworks (Spring/Hibernate) use ByteBuddy/CGLIB bytecode generation, faster but more complex
+
+## Case 4: JVM Parameter Tuning (Container Microservice)
+
+### Problem
+
+Spring Boot 3 microservice (JDK 17), deployed in 4GB memory container. P99 latency 300ms after startup, target below 100ms.
+
+### Measure Baseline
+
+- Startup time: 25s
+- P99: 300ms
+- GC log: Full GC every 5 minutes, Young GC 200ms pause
+- `jcmd <pid> VM.flags`: Default G1, heap default value (about 1GB)
+
+### Locate
+
+1. **Heap too small**: Container 4GB, JVM defaults based on physical machine -> heap about 1GB, frequent GC
+2. **No warmup**: JIT hasn't compiled to tier 4, methods all run in interpreted mode
+3. **GC log not enabled**: Difficult to debug
+
+### Optimize
+
+**Step 1: Container heap ratio + GC log**
+
+```
+-XX:+UseContainerSupport
+-XX:InitialRAMPercentage=50.0
+-XX:MaxRAMPercentage=75.0
+-XX:+UseG1GC
+-XX:MaxGCPauseMillis=200
+-XX:MetaspaceSize=256m
+-XX:MaxMetaspaceSize=512m
+-Xlog:gc*:file=/var/log/gc.log:time,uptime:filecount=10,filesize=10M
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath=/var/log/dumps/
+-XX:+AlwaysPreTouch
+-XX:+DisableExplicitGC
+```
+
+**Changes**:
+- Heap from 1GB -> 3GB (container 4GB x 75%)
+- GC log enabled
+- AlwaysPreTouch pre-touches memory at startup, reduces runtime page fault pauses
+
+**Step 2: JFR monitoring**
+
+```
+-XX:StartFlightRecording=filename=/var/log/jfr/app.jfr,maxage=1h,maxsize=100M,settings=profile
+-XX:FlightRecorderOptions=stackdepth=64
+```
+
+**Step 3: Application-level optimization**
+
+- Warmup: Send mock traffic for 5 minutes after startup
+- Logging framework: Async logging (Logback `AsyncAppender`)
+- HTTP client: Connection pool (OkHttp)
+
+### Verify
+
+| Metric | Baseline | After Optimization |
+|---|---|---|
+| Startup time | 25s | 22s (warmup takes 5s) |
+| P99 latency | 300ms | 85ms |
+| Full GC | Every 5 minutes | 0 (eliminated) |
+| Young GC pause | 200ms | 80ms |
+| Heap occupancy | 90% (frequent GC) | 60% |
+
+**JFR analysis**: Found 5% time still in `Object.wait` (connection pool wait); increased HikariCP connection pool 10 -> 20, P99 further dropped to 70ms.
+
+### Reflection
+
+- Must use `UseContainerSupport` + RAM percentage in containers
+- GC log + JFR must be enabled; no monitoring, no optimization
+- Warmup helps long-running services; for short-running applications use GraalVM
+- Don't tune too many parameters at once; verify in stages
+
+## Case 5: Escape Analysis Invalidation Scenario
+
+### Problem
+
+Log formatting method creates `StringBuilder` each call; should be eliminated by escape analysis, but GC log shows allocation hotspot.
+
+Code:
+```java
+public String format(LogRecord record) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(record.getTimestamp());
+    sb.append(" ");
+    sb.append(record.getLevel());
+    sb.append(" ");
+    sb.append(record.getMessage());
+    return sb.toString();
+}
+```
+
+### Locate
+
+Escape analysis should determine `sb` doesn't escape -> scalar replacement. But JFR shows `StringBuilder` is still allocated on heap.
+
+**Reason**: After C2 compiles the method, although `sb` doesn't escape the method, `sb.toString()` creates a new String object that does escape the method -> JIT conservatively doesn't eliminate `sb`.
+
+### Verify JIT Behavior
+
+```bash
+# Add at startup
+-XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining -XX:+PrintEscapeAnalysis
+```
+
+Output:
+```
+ EscapeAnalysis:
+   StringBuilder sb = new -- ArgEscape (toString returns)
+```
+
+### Optimize
+
+**Option 1**: Direct string concatenation (compiler auto-uses StringBuilder, but simpler):
+```java
+public String format(LogRecord record) {
+    return record.getTimestamp() + " " + record.getLevel() + " " + record.getMessage();
+}
+```
+
+**Option 2**: Make method final, let JIT inline more aggressively:
+```java
+public final String format(LogRecord record) { ... }
+```
+
+**Option 3**: Use `String.format` (worse performance, avoid)
+
+### Verify
+
+- JFR: StringBuilder allocation hotspot disappeared
+- GC frequency reduced 20%
+
+### Reflection
+
+- Escape analysis is not omnipotent; may fail in complex scenarios
+- Simple string concatenation with `+` is more thoroughly optimized by the compiler
+- Use `-XX:+PrintEscapeAnalysis` to verify on critical paths
+
+## Case 6: ZGC Switch (Large Heap Low Latency)
+
+### Problem
+
+Cache service heap 32GB, G1 Young GC pause 300ms, business P99 stuck at 500ms. SLA requires P99 < 100ms.
+
+### Measure Baseline
+
+- G1: Young GC pause 300ms, Full GC every 1 hour for 1.5s
+- P99 latency: 500ms (requests pile up during GC)
+
+### Optimize
+
+```
+-Xms32g -Xmx32g
+-XX:+UseZGC                       # JDK 17 non-generational ZGC
+-XX:ZAllocationSpikeTolerance=2
+-XX:ConcGCThreads=8              # 16-core machine, half for GC
+-XX:MetaspaceSize=512m
+-XX:MaxMetaspaceSize=1g
+-Xlog:gc*:file=/var/log/gc.log:time,uptime:filecount=20,filesize=50M
+```
+
+### Verify
+
+| Metric | G1 | ZGC |
+|---|---|---|
+| GC pause | 300ms | < 5ms |
+| P99 latency | 500ms | 80ms |
+| GC throughput | 95% | 98% |
+| CPU usage | 60% | 75% (concurrent GC uses more) |
+
+**Note**: JDK 17 ZGC is non-generational, CPU usage is slightly higher. If heap is larger (64GB+) and throughput-sensitive, upgrade to JDK 21 for generational ZGC.
+
+### Reflection
+
+- Large heap + low latency -> ZGC
+- ZGC is not free; higher CPU usage trades for lower pause
+- JDK 17 non-generational ZGC; JDK 21+ generational ZGC has better performance
+
+## General Tuning Methodology
+
+### Workflow
+
+1. **Measure baseline**: JMH / JFR / GC log to get current data
+2. **Locate bottleneck**: Flame graph / JFR to find hotspots
+3. **Optimize**: Change only one variable at a time
+4. **Verify**: Compare against baseline, look at confidence interval
+5. **Production validation**: Microbenchmark results may not represent real load; A/B test
+
+### Anti-patterns
+
+- Tuning without measuring -> mostly no benefit
+- Changing multiple variables -> don't know which one worked
+- Deploying based on microbenchmark alone -> doesn't represent real load
+- Over-optimizing -> 5% benefit for 50% time investment, not worth it
+
+### Benefit Ranking (General Case)
+
+1. **Algorithm layer**: O(n^2) -> O(n log n) benefit >> everything else
+2. **Data structure layer**: ArrayList vs LinkedList, HashMap vs TreeMap
+3. **Code layer**: Loop-invariant code motion, object reuse, StringBuilder caching
+4. **JVM layer**: GC parameters, heap size
+5. **Hardware layer**: CPU / memory / SSD
+
+Work from top to bottom; diminishing returns at lower layers.
+
+## Reference Documentation
+
+- In-project reactive troubleshooting cases: `../../jvm-troubleshoot/references/troubleshooting_cases.md`
+- In-project JMH details: `jmh_profiling.md`
+- In-project code-level optimization: `code_level_optimization.md`
+- JMH official samples: `https://github.com/openjdk/jmh/tree/main/jmh-samples/src/main/java/org/openjdk/jmh/samples`

--- a/.claude/skills/refactor-guide/SKILL.md
+++ b/.claude/skills/refactor-guide/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: refactor-guide
+description: Project refactoring standards and process governance. Automatically applied when users want to refactor code, split classes, extract methods, add tests, change signatures, or change architecture, ensuring refactoring is safe and verifiable. Related keywords: refactoring, refactor, extract method, split class, add tests, characterization test, Strangler Fig, L1-L4 refactoring granularity, safe refactoring. Not applicable to: coding style issues (use coding-standard), JVM troubleshooting (use jvm-troubleshoot), new feature development (not refactoring).
+---
+
+# Project Refactoring Standards and Process Governance
+
+This skill addresses the core pain points of refactoring: **refactoring without tests, no verification after changes, interruptions mid-refactoring, introducing new bugs**. The principle is "add tests first, then verify; take small steps."
+
+## Pre-Refactoring Checklist (Stop If Not Satisfied)
+
+All of the following must be met before refactoring. No exceptions:
+
+- [ ] **Sufficient test coverage**: Core logic coverage > 70%. No tests -> add "characterization tests" first (record current behavior, even if it has bugs), then refactor
+- [ ] **Tests are currently green**: `mvn test` passes, establishing a "it was working before refactoring" baseline
+- [ ] **Clear refactoring goal**: Can state in one sentence "what problem this refactoring solves", not "just tidying up while I'm at it"
+- [ ] **Rollback plan**: Work on a separate git branch, or have a backup
+- [ ] **Refactoring scope is defined**: List the files to be changed; do not change code outside the scope just because it "looks bad"
+
+**How to write characterization tests** (emergency when there are no tests):
+```java
+// Record current behavior, do not judge right or wrong
+@Test
+void characterize_currentBehavior_ofCalc() {
+    assertEquals(42, calc.compute(1, 2, 3));  // Even if 42 is a bug, record it first
+    assertEquals(0, calc.compute(0, 0, 0));
+    assertNull(calc.compute(null, null, null));  // Record current NPE too
+}
+```
+
+## Refactoring Granularity Levels
+
+4 levels by risk and impact scope, each with different process requirements:
+
+| Level | Scope | Example | Process Requirements |
+|---|---|---|---|
+| **L1 Surface Refactoring** | Single file, no signature change | Rename variable, extract constant, format adjustment | Run unit tests after changes |
+| **L2 Structural Refactoring** | Single file, change internal structure | Extract method, inline method, move function | Run unit tests + integration tests after changes |
+| **L3 Interface Refactoring** | Multiple files, change signature | Change method signature, split class, merge classes | Change tests first, then implementation, run full test suite |
+| **L4 Architecture Refactoring** | Cross-module, change dependencies | Switch framework, split microservices, change data flow | Phased approach, each phase independently testable and rollbackable |
+
+**How to determine level**: If changes affect callers -> at least L3; if cross-module -> L4.
+
+## Standard Refactoring Process (5 Steps, Small Steps)
+
+1. **Green baseline**: `mvn test` passes. If it fails, fix bugs first. Do not refactor on broken code.
+2. **Add tests**: Add tests for the code to be changed. If coverage is insufficient, add more cases. Focus on **the parts being changed** and **affected callers**.
+3. **Small-step refactoring**: Only one atomic action per step (extract one method / rename one variable / move one function). Run tests immediately after each change.
+4. **Commit checkpoint**: `git commit` after each atomic refactoring. Write clear commit messages describing what was done. This enables `git bisect` for locating issues and `git revert` for rollback.
+5. **Verify**: Run full test suite + integration tests + manual verification of critical paths. L3/L4 also requires performance baseline comparison.
+
+**Key principle**: Do not make 10 changes then run tests. When something breaks, you cannot pinpoint which step introduced the problem.
+
+## Refactoring Action List
+
+Standard approaches for common refactoring scenarios:
+
+| Scenario | Refactoring Action | Notes |
+|---|---|---|
+| Method too long | Extract Method | After extraction, method name should express intent; if too many parameters, encapsulate into an object |
+| Duplicate code | Extract common method / Template Method | Do not over-abstract; extract only after **3 repetitions** (rule of three) |
+| Class too large | Split class / Extract responsibility | First ask "how many responsibilities does this class have"; only split when Single Responsibility is violated |
+| Deep nesting | Extract method / Early return / Guard clause | Reduce nesting levels; prefer guard clauses for early return |
+| Magic numbers | Extract constant | Constant name should express business meaning, not `NUM_42` |
+| Too many parameters | Encapsulate parameter object | Do not create a "parameter bag" anti-pattern (one class holding all parameters) |
+| Switch branches | Replace with polymorphism / Strategy pattern | Use switch for fixed branches; use Strategy pattern for extensible branches |
+| Global variables | Dependency injection | Reduce static; use constructor injection or method injection |
+| Complex conditions | Extract judgment method / Strategy pattern | `if (a && b || c)` -> `if (shouldExecute(a, b, c))` |
+
+## Safe Refactoring Techniques
+
+4 patterns to avoid "code breaks mid-refactoring":
+
+### 1. Strangler Fig Pattern
+
+New code gradually replaces old code; old code is kept until verification is complete, then deleted:
+
+```
+// Phase 1: New implementation coexists
+public Result process(Input in) {
+    if (featureFlag.useNew()) {
+        return newProcess(in);   // New implementation
+    }
+    return oldProcess(in);       // Old implementation kept
+}
+
+// Phase 2: After canary verification, traffic switches to new implementation
+// Phase 3: Delete old implementation
+```
+
+Applicable to: L4 architecture refactoring, replacing entire modules.
+
+### 2. Parallel Implementation + Toggle Switch
+
+New and old implementations coexist, configuration toggle switches between them; instant rollback if problems occur:
+
+```java
+if (config.getBoolean("use.new.parser")) {
+    return newParser.parse(input);
+} else {
+    return oldParser.parse(input);
+}
+```
+
+Applicable to: Switching frameworks, algorithms, or data sources.
+
+### 3. Shadow Traffic
+
+New and old implementations run simultaneously, results are compared, without affecting production:
+
+```java
+Result official = oldProcess(input);          // Production uses this
+Result shadow = newProcess(input);             // Shadow run, does not affect return
+logCompare(official, shadow);                  // Compare, alert on inconsistency
+return official;
+```
+
+Applicable to: Core path refactoring where direct switchover is not possible.
+
+### 4. Commit Checkpoints
+
+`git commit` after each atomic refactoring, enabling rollback and bisect:
+
+```bash
+git commit -m "refactor: extract computeTax method from calculate"
+# Run tests, green
+git commit -m "refactor: rename price -> unitPrice"
+# Run tests, red -> git revert HEAD, go back to previous step
+```
+
+Applicable to: All levels of refactoring, **mandatory**.
+
+## Anti-Patterns (Do Not Refactor This Way)
+
+| Anti-Pattern | Problem | Correct Approach |
+|---|---|---|
+| **Big Bang refactoring** | Change for a week before running tests; cannot locate issues when something breaks | Small steps, commit + test at each step |
+| **Opportunistic refactoring** | Tidying up unrelated code while fixing a bug, expanding the change scope | Refactoring and bug fixes in separate commits, separate PRs |
+| **Refactoring without tests** | Changing code based on "I understand this code" | Add characterization tests first, then refactor |
+| **Refactoring + logic change** | Mixing refactoring with behavior changes, impossible to distinguish | Refactoring does not change behavior; logic changes in separate commits |
+| **Cross-branch refactoring** | Multiple branches refactoring simultaneously, merge conflict hell | Complete refactoring in one branch, then cherry-pick |
+
+## Phased Strategy for L3/L4 Refactoring
+
+L3 (interface refactoring) and L4 (architecture refactoring) must be phased, with each phase independently testable and rollbackable:
+
+### L3 Interface Refactoring Example (Change Method Signature)
+
+```
+Phase 1: New signature + old signature coexist (old signature delegates to new signature)
+Phase 2: All callers migrate to new signature
+Phase 3: Delete old signature
+```
+
+One commit per phase, run full test suite after each phase.
+
+### L4 Architecture Refactoring Example (Split Microservices)
+
+```
+Phase 1: Set up new service, no traffic (independently testable)
+Phase 2: Strangler Fig connects to new service, shadow traffic comparison
+Phase 3: Canary traffic shift to new service
+Phase 4: Decommission old service
+```
+
+Phases may be weeks apart; each phase must have a rollback plan.
+
+## Refactoring Completion Acceptance Criteria
+
+When refactoring is done, check:
+
+- [ ] Full test suite passes (including integration tests)
+- [ ] No new test failures introduced
+- [ ] Behavior unchanged (L1/L2/L3) or behavior changes verified (L4)
+- [ ] Code is clearer (readability improved, not more complex)
+- [ ] No new code smells introduced
+- [ ] No performance regression (L3/L4 run performance baseline comparison)
+- [ ] Dead code removed (old implementations, unused imports)
+
+## Usage
+
+1. **Pre-check**: Go through the 5 "pre-refactoring checklist" items before refactoring; if tests are missing, add characterization tests first.
+2. **Determine level**: Use the "granularity levels" table to determine L1-L4, and select corresponding process requirements.
+3. **Execute process**: Follow the 5 "standard refactoring process" steps; take small steps, commit + test at each step.
+4. **Select action**: Use the "refactoring action list" to find the standard approach for the scenario; for code examples, Read `references/refactor-guide/references/refactoring_patterns.md`.
+5. **Legacy code**: For old code without tests, Read `refactor-guide/references/legacy_code_patterns.md`, use seam points + characterization tests + dependency breaking.
+6. **Real cases**: For end-to-end reference, Read `refactor-guide/references/refactoring_cases.md` (4 cases: Service splitting / static to injection / microservice splitting / add tests then refactor).
+7. **Safety strategies**: For L3/L4, use Strangler Fig / parallel implementation / commit checkpoints; avoid big bang.
+8. **Acceptance**: Check against "acceptance criteria" to verify refactoring is truly complete.
+9. **Do not fabricate when uncertain**: Refactoring techniques are based on "Refactoring" and "Working Effectively with Legacy Code"; this skill does not replace formal methodologies.
+
+## Reference Entries
+
+- **Refactoring Techniques in Detail**: `references/refactoring_patterns.md` (9 techniques, with before/after code comparison)
+- **Legacy Code Refactoring**: `references/legacy_code_patterns.md` (seam points, characterization tests, 6 dependency-breaking techniques)
+- **Real Refactoring Cases**: `references/refactoring_cases.md` (4 end-to-end cases)
+- "Refactoring: Improving the Design of Existing Code" (Martin Fowler)
+- "Working Effectively with Legacy Code" (Michael Feathers) -- covers legacy code refactoring, characterization tests
+- Project coding standards: `resources/skills/coding-standard/SKILL.md`
+- Project JVM troubleshooting: `resources/skills/jvm-troubleshoot/SKILL.md`

--- a/.claude/skills/refactor-guide/references/legacy_code_patterns.md
+++ b/.claude/skills/refactor-guide/references/legacy_code_patterns.md
@@ -1,0 +1,256 @@
+# Legacy Code Refactoring
+
+This file addresses how to safely refactor "old code without tests," based on "Working Effectively with Legacy Code." Read on demand when users say "I'm afraid to change code without tests" or "how to add tests to old code."
+
+## Core Concept: Seam
+
+**Seam**: A point where behavior can be altered without modifying the code. The key to legacy code refactoring is finding seam points and injecting tests.
+
+| Seam Type | Example | Testing Approach |
+|---|---|---|
+| **Method parameter** | `process(data, parser)` | Pass mock parser |
+| **Constructor injection** | `new Service(repo)` | Pass mock repo |
+| **Method override** | Subclass overrides `protected` method | Test the subclass |
+| **Interface extraction** | Change static call to interface | Pass mock interface |
+
+## Characterization Test
+
+Record current behavior (even if it has bugs), do not change logic. After refactoring, run characterization tests; if behavior is unchanged, it is safe.
+
+### Scenario 1: Pure Functional Logic
+
+```java
+// Original code
+public class TaxCalculator {
+    public double calculate(double amount, String type) {
+        if ("VIP".equals(type)) return amount * 0.8;
+        if (amount > 1000) return amount * 0.9;
+        return amount;
+    }
+}
+
+// Characterization test: record all current boundary behaviors
+@Test
+void characterize_taxCalc() {
+    TaxCalculator calc = new TaxCalculator();
+    assertEquals(80.0, calc.calculate(100, "VIP"));       // VIP 20% off
+    assertEquals(800.0, calc.calculate(1000, "VIP"));      // VIP 20% off (regardless of amount)
+    assertEquals(900.0, calc.calculate(1000, "NORMAL"));   // Non-VIP over 1000 gets 10% off
+    assertEquals(100.0, calc.calculate(100, "NORMAL"));    // Non-VIP under 1000 full price
+    assertEquals(100.0, calc.calculate(100, null));         // type null treated as normal
+    assertEquals(0.0, calc.calculate(0, "VIP"));           // Boundary: 0
+    assertEquals(0.0, calc.calculate(-100, "VIP"));        // Negative (record bug as-is)
+}
+```
+
+### Scenario 2: Logic with Side Effects (Use Spy to Record Calls)
+
+```java
+// Original code: has logger and DB calls
+public class OrderService {
+    public void place(Order order) {
+        log.info("placing " + order.getId());
+        db.save(order);
+        email.send(order.getCustomerEmail(), "Order placed");
+    }
+}
+
+// Characterization test: use spy to record calls, do not verify "right or wrong", only verify "what was called"
+@Test
+void characterize_place_callsLoggerDbAndEmail() {
+    // Wrap dependencies with spies
+    OrderService svc = new OrderService(logSpy, dbSpy, emailSpy);
+    svc.place(new Order("o1", "alice@example.com", 100));
+
+    // Record current behavior: what logger called, what db saved, what email sent
+    verify(logSpy).info("placing o1");
+    assertThat(dbSpy.saved).containsExactly(new Order("o1", "alice@example.com", 100));
+    assertThat(emailSpy.sent).hasSize(1);
+    assertThat(emailSpy.sent.get(0).getTo()).isEqualTo("alice@example.com");
+    assertThat(emailSpy.sent.get(0).getBody()).isEqualTo("Order placed");
+}
+```
+
+### Scenario 3: Complex Conditional Branches (Record Output for Each Branch)
+
+```java
+// Use parameterized test to cover all branches
+@ParameterizedTest
+@CsvSource({
+    "100, VIP, 80.0",
+    "1000, VIP, 800.0",
+    "1000, NORMAL, 900.0",
+    "100, NORMAL, 100.0",
+    "0, VIP, 0.0",
+    "-100, VIP, -80.0"  // Record negative too, even if buggy
+})
+void characterize_branches(double amount, String type, double expected) {
+    assertEquals(expected, calc.calculate(amount, type));
+}
+```
+
+## Dependency-Breaking Techniques
+
+Legacy code is untestable mainly because dependencies are hardcoded. 6 techniques for breaking dependencies:
+
+### 1. Extract Interface
+
+**Applicable to**: Static calls or hardcoded `new` dependencies that cannot be injected with mocks.
+
+```java
+// Before refactoring: hard dependency on DateUtil.now(), cannot mock
+public class OrderService {
+    public Order create() {
+        return new Order(DateUtil.now());  // static, untestable
+    }
+}
+
+// After refactoring: extract interface, constructor injection
+public interface TimeProvider {
+    long now();
+}
+public class OrderService {
+    private final TimeProvider time;
+    public OrderService(TimeProvider time) { this.time = time; }
+    public Order create() {
+        return new Order(time.now());  // Can inject mock
+    }
+}
+// Production code: new OrderService(new SystemTimeProvider())
+// Test code: new OrderService(() -> 1700000000000L)  // Fixed time
+```
+
+### 2. Parameterize Method
+
+**Applicable to**: Method internally `new`s a dependency; change the dependency to a parameter.
+
+```java
+// Before refactoring
+public Result process(String input) {
+    Parser parser = new JsonParser();  // Hard new, cannot swap
+    return parser.parse(input);
+}
+
+// After refactoring
+public Result process(String input) {
+    return process(input, new JsonParser());  // Delegate to parameterized version
+}
+public Result process(String input, Parser parser) {  // Testable
+    return parser.parse(input);
+}
+// Test: svc.process("{}", new MockParser())
+```
+
+### 3. Subclass and Override
+
+**Applicable to**: Method calls an untestable dependency; use subclass to override method for isolation.
+
+```java
+// Before refactoring
+public class ReportService {
+    public String generate() {
+        Data data = fetchFromDB();  // protected method, connects to DB
+        return format(data);
+    }
+    protected Data fetchFromDB() {
+        return realDb.query(...);  // Untestable
+    }
+}
+
+// Test: override fetchFromDB
+class TestableReportService extends ReportService {
+    @Override
+    protected Data fetchFromDB() {
+        return new Data("test");  // No DB connection
+    }
+}
+@Test
+void generate_formatsData() {
+    TestableReportService svc = new TestableReportService();
+    assertEquals("formatted: test", svc.generate());
+}
+```
+
+### 4. Link Seam
+
+**Applicable to**: Dependency is a static method that cannot be overridden. Replace implementation via classpath.
+
+```java
+// Before refactoring: static call
+public class Service {
+    public void doWork() {
+        Config cfg = ConfigLoader.load();  // static, reads from file
+        // ...
+    }
+}
+
+// Test: replace ConfigLoader with same-named class on test classpath
+// src/test/java/.../ConfigLoader.java
+public class ConfigLoader {
+    public static Config load() {
+        return new Config("test-value");  // Test version returns fixed value
+    }
+}
+```
+
+**Note**: This is a last resort; it is highly disruptive. Use with caution.
+
+### 5. Instance Delegation
+
+**Applicable to**: Too many static method calls; wrap statics as instances.
+
+```java
+// Before refactoring
+public double calc(Order o) {
+    double base = PricingEngine.compute(o);      // static
+    double tax = TaxUtil.calculate(base);        // static
+    return base + tax;
+}
+
+// After refactoring: wrap as instances
+public class PricingService {
+    public double compute(Order o) { return PricingEngine.compute(o); }  // Wrapper
+}
+public class TaxService {
+    public double calculate(double base) { return TaxUtil.calculate(base); }
+}
+// Inject into Service
+public double calc(Order o, PricingService pricing, TaxService tax) {
+    double base = pricing.compute(o);
+    return base + tax.calculate(base);
+}
+```
+
+### 6. Wrap Method / Wrap Class
+
+**Applicable to**: Cannot modify the original method, but need to add logic before/after (logging/caching/validation).
+
+```java
+// Before refactoring
+public void save(Order o) {
+    db.insert(o);
+}
+
+// Wrap method (do not modify original method)
+public void saveWithLog(Order o) {
+    log.info("saving " + o.getId());
+    save(o);  // Original method untouched
+    log.info("saved " + o.getId());
+}
+```
+
+## Legacy Code Refactoring Process
+
+1. **Find seam points**: Where can tests be injected (parameters/constructor/override/interface)
+2. **Write characterization tests**: Record current behavior at seam points
+3. **Break dependencies**: Use one of the 6 techniques above to break hard dependencies
+4. **Add tests**: After breaking dependencies, formal tests can be written
+5. **Small-step refactoring**: Run characterization tests at each step; behavior must not change
+6. **Delete characterization tests**: After refactoring is complete and formal tests provide coverage, characterization tests can be removed
+
+## Key Principles
+
+- **Legacy code = code without tests** (Michael Feathers' definition), not "old code"
+- **Add tests first, then change code**: The order must not be reversed
+- **Characterization tests do not judge right or wrong**: Record the current state, even bugs are recorded; fix bugs after refactoring
+- **Only break the minimum necessary dependencies**: Do not over-engineer for "testability"; break" just enough to test

--- a/.claude/skills/refactor-guide/references/refactoring_cases.md
+++ b/.claude/skills/refactor-guide/references/refactoring_cases.md
@@ -1,0 +1,333 @@
+# Real Refactoring Cases
+
+This file provides 4 end-to-end cases, each containing "current state -> problem -> refactoring steps -> verification -> result." Read on demand when users ask "give me a refactoring case" or "how to refactor this kind of problem."
+
+## Case 1: Splitting a 1000-Line Service Class (L2 Structural Refactoring)
+
+### Current State
+
+`OrderService` is 1100 lines, containing 5 responsibilities: order creation, payment, logistics, notification, and reporting. Changing any single piece of logic requires searching through 1000 lines, making it easy to introduce errors.
+
+### Problem
+
+- Severe Single Responsibility violation
+- Tests are hard to write: testing "create order" requires mocking payment/logistics/notification dependencies
+- Multiple people editing the same file causes frequent conflicts
+
+### Refactoring Steps
+
+**Phase 1: Add Characterization Tests**
+
+First, write a set of characterization tests for each of the 5 responsibilities to be split, recording current behavior.
+
+```java
+@Test
+void characterize_createOrder() {
+    Order o = svc.create(new OrderRequest("alice", "sku1", 2));
+    assertEquals("PENDING", o.getStatus());
+    assertNotNull(o.getId());
+    verify(notifier).notifyCustomer("alice", "order created");
+}
+```
+
+**Phase 2: Extract Class**
+
+Split into 5 classes by responsibility; old Service temporarily delegates:
+
+```java
+public class OrderService {
+    private final OrderCreator creator;
+    private final PaymentProcessor payment;
+    private final LogisticsTracker logistics;
+    private final NotificationService notifier;
+    private final ReportGenerator reports;
+
+    public Order create(OrderRequest req) { return creator.create(req); }
+    public void pay(Order o) { payment.pay(o); }
+    // ... delegate
+}
+```
+
+Commit once + run characterization tests after extracting each class.
+
+**Phase 3: Migrate Callers**
+
+Gradually change `orderService.create(...)` to `orderCreator.create(...)`, migrating in separate PRs.
+
+**Phase 4: Delete Old Service Delegates**
+
+After all callers have migrated, `OrderService` only contains composition and delegation, and can be deleted.
+
+### Verification
+
+- All characterization tests green (behavior unchanged)
+- Each new class has independent tests (testability improved)
+- No conflicts in multi-person development
+
+### Result
+
+1100 lines -> 5 classes of ~200 lines each, each with a single responsibility.
+
+---
+
+## Case 2: Static Calls to Dependency Injection (L3 Interface Refactoring)
+
+### Current State
+
+Business code calls `DateUtil.now()` and `ConfigLoader.load()` everywhere; static methods cannot be mocked, so tests either skip or write integration tests connecting to real dependencies.
+
+### Problem
+
+- Low unit test coverage, connecting to real DB/file system
+- Slow tests, CI reluctant to run them
+
+### Refactoring Steps
+
+**Phase 1: Extract Interface**
+
+Wrap statics into interfaces:
+
+```java
+public interface TimeProvider { long now(); }
+public interface ConfigProvider { Config load(); }
+
+public class SystemTimeProvider implements TimeProvider {
+    public long now() { return System.currentTimeMillis(); }
+}
+public class FileConfigProvider implements ConfigProvider {
+    public Config load() { return ConfigLoader.load(); }
+}
+```
+
+**Phase 2: New Signature + Old Signature Coexist**
+
+```java
+public class OrderService {
+    private final TimeProvider time;
+    private final ConfigProvider config;
+
+    // New constructor (for production)
+    public OrderService(TimeProvider time, ConfigProvider config) {
+        this.time = time; this.config = config;
+    }
+
+    // Old constructor (backward compatible, defaults to System implementation)
+    public OrderService() {
+        this(new SystemTimeProvider(), new FileConfigProvider());
+    }
+
+    public Order create() {
+        return new Order(time.now(), config.load().getDefaultCurrency());
+    }
+}
+```
+
+**Phase 3: Migrate Callers**
+
+Callers gradually change from `new OrderService()` to `new OrderService(timeProvider, configProvider)`.
+
+**Phase 4: Delete Old Constructor**
+
+After all callers have migrated, delete the no-arg constructor, enforcing injection.
+
+### Verification
+
+```java
+@Test
+void create_usesFixedTime() {
+    OrderService svc = new OrderService(() -> 1700000000000L, () -> testConfig);
+    Order o = svc.create();
+    assertEquals(1700000000000L, o.getCreatedAt());
+}
+```
+
+Unit tests no longer connect to real dependencies; CI is 5x faster.
+
+### Result
+
+All static dependencies changed to injection; unit test coverage 40% -> 85%.
+
+---
+
+## Case 3: Monolith to Microservices (L4 Architecture Refactoring)
+
+### Current State
+
+Orders, inventory, and payments are in the same Spring Boot application; deployment is coupled; changing inventory requires restarting the entire application.
+
+### Problem
+
+- Deployment coupling: small modules require full releases
+- Poor resource isolation: report queries drag down order creation
+- Unclear team boundaries: everyone edits the same repository
+
+### Refactoring Steps
+
+**Phase 1: Set Up New Service, No Traffic**
+
+Create a new `inventory-service` standalone application; first move inventory logic there (no traffic, independently testable).
+
+```
+monolith/
+└── inventory/ (old implementation, kept)
+inventory-service/ (new implementation, independently deployed)
+```
+
+**Phase 2: Strangler Fig Integration**
+
+Change inventory calls in the monolith to dual-write + shadow:
+
+```java
+public void updateStock(String sku, int qty) {
+    legacyInventoryRepo.update(sku, qty);              // Old implementation, still in use
+    inventoryServiceClient.update(sku, qty);            // New service, shadow call
+    // Shadow only records results, does not affect return
+}
+```
+
+Compare data consistency on both sides; fix new service first if issues are found.
+
+**Phase 3: Canary Traffic Shift**
+
+Add feature flag, shift to new service by SKU or percentage:
+
+```java
+public void updateStock(String sku, int qty) {
+    if (featureFlag.useNewInventory(sku)) {  // Canary
+        inventoryServiceClient.update(sku, qty);
+    } else {
+        legacyInventoryRepo.update(sku, qty);
+    }
+}
+```
+
+During canary period, monitor new service latency, error rate, and data consistency.
+
+**Phase 4: Decommission Old Implementation**
+
+After canary reaches 100% and is stable, delete `monolith/inventory/`; old code is fully decommissioned.
+
+### Verification
+
+- Each phase independently testable and rollbackable
+- Data consistency 99.99%+ during canary period
+- New service latency < old implementation
+
+### Result
+
+Split completed in 3 months; inventory service independently deployed; team boundaries clear.
+
+---
+
+## Case 4: Add Tests Then Refactor (Legacy Code Without Tests)
+
+### Current State
+
+`PricingEngine` is 500 lines, zero tests, pure legacy code. Need to add a new pricing rule but afraid to change it.
+
+### Problem
+
+- No tests; cannot tell if changes break existing behavior
+- Methods internally `new` dependencies (`new DateUtil()`, `new DiscountCalculator()`), cannot mock
+
+### Refactoring Steps
+
+**Phase 1: Find Seam Points**
+
+The `compute` method internally `new`s `DiscountCalculator`; this is a seam point -- can extract interface for injection.
+
+```java
+// Original code
+public double compute(Order order) {
+    DiscountCalculator dc = new DiscountCalculator(order);  // Hard new
+    double base = order.getAmount();
+    double discount = dc.calculate();
+    return base - discount + TaxUtil.compute(base - discount);  // static
+}
+```
+
+**Phase 2: Write Characterization Tests (Break Dependencies First)**
+
+Use "Parameterize Method" to break hard dependencies:
+
+```java
+// Extract injectable version
+public double compute(Order order) {
+    return compute(order, new DiscountCalculator(order), TaxUtil::compute);
+}
+
+// Version with dependencies, testable
+double compute(Order order, DiscountCalculator dc, Function<Double, Double> taxFn) {
+    double base = order.getAmount();
+    double discount = dc.calculate();
+    return base - discount + taxFn.apply(base - discount);
+}
+```
+
+Write characterization tests, recording all boundaries:
+
+```java
+@Test
+void characterize_compute_normal() {
+    double r = engine.compute(new Order(100), new DiscountCalculator(0.1), t -> t * 0.1);
+    assertEquals(99.0, r);  // 100 - 10 + 9
+}
+
+@Test
+void characterize_compute_zeroDiscount() {
+    double r = engine.compute(new Order(100), new DiscountCalculator(0), t -> 0);
+    assertEquals(100.0, r);
+}
+
+@Test
+void characterize_compute_zeroAmount() {
+    double r = engine.compute(new Order(0), new DiscountCalculator(0.1), t -> 0);
+    assertEquals(0.0, r);
+}
+```
+
+**Phase 3: Small-Step Refactoring**
+
+With characterization tests as a safety net, begin refactoring:
+- Extract method: extract tax calculation into `calculateTax(double)`
+- Extract constant: `0.1` into `DISCOUNT_RATE`
+- Simplify conditions: use early returns to reduce nesting
+
+Commit + run characterization tests at each step; if green, continue.
+
+**Phase 4: Add Formal Tests**
+
+After behavior stabilizes, add formal tests covering new logic (no longer just characterization tests):
+
+```java
+@Test
+void compute_vipCustomer_getsExtraDiscount() {
+    Order o = new Order(100, CustomerType.VIP);
+    double r = engine.compute(o);
+    assertEquals(80.0, r);  // VIP gets extra 10% off
+}
+```
+
+**Phase 5: Add New Feature**
+
+With tests in place, safely add new pricing rules.
+
+### Verification
+
+- All characterization tests green (behavior unchanged)
+- New tests cover new rules
+- Zero incidents during refactoring
+
+### Result
+
+Zero tests -> 80% coverage; adding new rules is now safe and testable.
+
+## Common Case Process
+
+| Phase | Action | Key Point |
+|---|---|---|
+| 1. Current state assessment | Review code scale, test coverage, dependency coupling | Determine refactoring level L1-L4 |
+| 2. Add tests | Add tests if they exist; write characterization tests if none | Break dependencies before writing tests |
+| 3. Small-step refactoring | One atomic action per step | Commit + test |
+| 4. Verification | Full test suite + integration tests | Behavior unchanged |
+| 5. Wrap-up | Delete dead code, delete characterization tests | Refactoring complete |

--- a/.claude/skills/refactor-guide/references/refactoring_patterns.md
+++ b/.claude/skills/refactor-guide/references/refactoring_patterns.md
@@ -1,0 +1,340 @@
+# Refactoring Techniques in Detail
+
+This file supplements the "Refactoring Action List" in SKILL.md, providing "before/after" code comparison and steps for each technique. Read on demand when users ask "how to do a specific technique."
+
+## 1. Extract Method
+
+**Motivation**: Method is too long; a section of code does an independent thing; the method name can express intent.
+
+**Before**:
+```java
+public void printOrder(Order order) {
+    System.out.println("Order: " + order.getId());
+    System.out.println("Customer: " + order.getCustomerName());
+    System.out.println("Total: " + order.getTotal());
+
+    double tax = order.getTotal() * 0.1;
+    double discount = order.getTotal() * 0.05;
+    System.out.println("Tax: " + tax);
+    System.out.println("Discount: " + discount);
+    System.out.println("Final: " + (order.getTotal() + tax - discount));
+}
+```
+
+**After**:
+```java
+public void printOrder(Order order) {
+    printOrderHeader(order);
+    printOrderPricing(order);
+}
+
+private void printOrderHeader(Order order) {
+    System.out.println("Order: " + order.getId());
+    System.out.println("Customer: " + order.getCustomerName());
+    System.out.println("Total: " + order.getTotal());
+}
+
+private void printOrderPricing(Order order) {
+    double tax = calculateTax(order.getTotal());
+    double discount = calculateDiscount(order.getTotal());
+    System.out.println("Tax: " + tax);
+    System.out.println("Discount: " + discount);
+    System.out.println("Final: " + (order.getTotal() + tax - discount));
+}
+
+private double calculateTax(double total) { return total * 0.1; }
+private double calculateDiscount(double total) { return total * 0.05; }
+```
+
+**Steps**:
+1. Create a new method whose name expresses "what it does" rather than "how it does it"
+2. Move the code segment into it; note whether local variables need to be passed as parameters
+3. Replace the original location with a method call
+4. Run tests
+
+## 2. Inline Method
+
+**Motivation**: The method body is clearer than the method name, or the method is only called once; remove the indirection.
+
+**Before**:
+```java
+public double getRating() {
+    return moreThanFiveLateDeliveries() ? 2 : 1;
+}
+private boolean moreThanFiveLateDeliveries() {
+    return numberOfLateDeliveries > 5;
+}
+```
+
+**After**:
+```java
+public double getRating() {
+    return numberOfLateDeliveries > 5 ? 2 : 1;
+}
+```
+
+**Steps**:
+1. Confirm the method is not overridden polymorphically
+2. Find all call sites
+3. Replace calls with the method body
+4. Delete the method
+5. Run tests
+
+## 3. Extract Class
+
+**Motivation**: A class does two responsibilities, violating Single Responsibility.
+
+**Before**:
+```java
+public class Person {
+    private String name;
+    private String officeAreaCode;
+    private String officeNumber;
+
+    public String getTelephoneNumber() {
+        return "(" + officeAreaCode + ") " + officeNumber;
+    }
+    // name-related methods + office-related methods mixed together
+}
+```
+
+**After**:
+```java
+public class Person {
+    private String name;
+    private TelephoneNumber officeTelephone;
+
+    public String getTelephoneNumber() {
+        return officeTelephone.getTelephoneNumber();
+    }
+}
+
+public class TelephoneNumber {
+    private String areaCode;
+    private String number;
+
+    public String getTelephoneNumber() {
+        return "(" + areaCode + ") " + number;
+    }
+}
+```
+
+**Steps**:
+1. Define a new class, move related fields to it
+2. Old class holds a reference to the new class (composition)
+3. Old class methods delegate to the new class
+4. Gradually migrate callers to use the new class directly
+5. Run tests
+
+## 4. Move Method
+
+**Motivation**: A method is in class A, but the data it uses is all in class B; it should be moved to B.
+
+**Before**:
+```java
+public class Account {
+    private AccountType type;
+    private int daysOverdrawn;
+
+    public double overdraftCharge() {
+        // Uses type's data, not Account's other fields
+        if (type.isPremium()) {
+            double result = 10;
+            if (daysOverdrawn > 7) result += (daysOverdrawn - 7) * 0.85;
+            return result;
+        }
+        return daysOverdrawn * 1.75;
+    }
+}
+```
+
+**After**:
+```java
+public class AccountType {
+    public double overdraftCharge(int daysOverdrawn) {  // Moved here
+        if (isPremium()) {
+            double result = 10;
+            if (daysOverdrawn > 7) result += (daysOverdrawn - 7) * 0.85;
+            return result;
+        }
+        return daysOverdrawn * 1.75;
+    }
+}
+
+public class Account {
+    private AccountType type;
+    private int daysOverdrawn;
+
+    public double overdraftCharge() {
+        return type.overdraftCharge(daysOverdrawn);  // delegate
+    }
+}
+```
+
+**Steps**:
+1. Create a new method in the target class, copy the logic, adjust parameters
+2. Change the old method to a delegate call
+3. Gradually have callers invoke the new method directly
+4. Delete the old method after no one calls it
+5. Run tests
+
+## 5. Replace Conditional with Polymorphism
+
+**Motivation**: switch/if-else branches on type; adding a new type requires changing all branches.
+
+**Before**:
+```java
+public double getSpeed() {
+    switch (type) {
+        case EUROPEAN: return getBaseSpeed();
+        case AFRICAN: return getBaseSpeed() - getLoadFactor() * numberOfCoconuts;
+        case NORWEGIAN: return isNailed ? 0 : getBaseSpeed(voltage);
+        default: throw new IllegalStateException();
+    }
+}
+```
+
+**After**:
+```java
+abstract class Bird {
+    abstract double getSpeed();
+}
+class European extends Bird {
+    double getSpeed() { return getBaseSpeed(); }
+}
+class African extends Bird {
+    double getSpeed() { return getBaseSpeed() - getLoadFactor() * numberOfCoconuts; }
+}
+class Norwegian extends Bird {
+    double getSpeed() { return isNailed ? 0 : getBaseSpeed(voltage); }
+}
+```
+
+**Steps**:
+1. Create a subclass for each type
+2. Replace construction with a factory method
+3. Move each branch to the corresponding subclass
+4. Change the parent class method to abstract
+5. Run tests
+
+## 6. Replace Switch with Strategy Pattern
+
+**Motivation**: Switch branches will expand, and you don't want to modify the class every time a branch is added.
+
+**Before**:
+```java
+public double calculate(PriceType type, double base) {
+    switch (type) {
+        case NORMAL: return base;
+        case DISCOUNT: return base * 0.9;
+        case VIP: return base * 0.8;
+        default: throw new IllegalArgumentException();
+    }
+}
+```
+
+**After**:
+```java
+interface PriceStrategy { double calculate(double base); }
+
+class NormalPrice implements PriceStrategy {
+    public double calculate(double base) { return base; }
+}
+class DiscountPrice implements PriceStrategy {
+    public double calculate(double base) { return base * 0.9; }
+}
+class VipPrice implements PriceStrategy {
+    public double calculate(double base) { return base * 0.8; }
+}
+
+// Register in Map, new strategies are added without modification
+Map<PriceType, PriceStrategy> strategies = Map.of(
+    NORMAL, new NormalPrice(),
+    DISCOUNT, new DiscountPrice(),
+    VIP, new VipPrice()
+);
+public double calculate(PriceType type, double base) {
+    return strategies.get(type).calculate(base);
+}
+```
+
+**Difference from Replace Conditional with Polymorphism**: Strategy pattern uses composition, switchable at runtime; polymorphism uses inheritance, determined at compile time.
+
+## 7. Introduce Parameter Object
+
+**Motivation**: Too many parameters that frequently appear together.
+
+**Before**:
+```java
+public Order createOrder(String customerId, String productId, int qty,
+                         double price, String address, String coupon) { ... }
+```
+
+**After**:
+```java
+public class OrderRequest {
+    private String customerId;
+    private String productId;
+    private int qty;
+    private BigDecimal price;  // Also changed double to BigDecimal
+    private String address;
+    private String coupon;
+    // builder
+}
+public Order createOrder(OrderRequest req) { ... }
+```
+
+**Note**: Do not create a "parameter bag" (one class holding parameters for all methods); each method should have its own parameter object.
+
+## 8. Replace Temp with Query
+
+**Motivation**: A temporary variable is assigned and only read once; a query method is clearer.
+
+**Before**:
+```java
+double basePrice = quantity * itemPrice;
+if (basePrice > 1000) {
+    return basePrice * 0.95;
+} else {
+    return basePrice * 0.98;
+}
+```
+
+**After**:
+```java
+if (basePrice() > 1000) {
+    return basePrice() * 0.95;
+} else {
+    return basePrice() * 0.98;
+}
+private double basePrice() {
+    return quantity * itemPrice;
+}
+```
+
+**Note**: If the computation is heavy or will be called multiple times, keeping the temporary variable is better (performance).
+
+## 9. Introduce Explaining Variable
+
+**Motivation**: Complex expressions are hard to understand; break them into named variables.
+
+**Before**:
+```java
+if ((platform.toUpperCase().indexOf("MAC") > -1) &&
+    (browser.toUpperCase().indexOf("IE") > -1) &&
+    wasInitialized() && resize > 0) {
+    // do something
+}
+```
+
+**After**:
+```java
+boolean isMacOs = platform.toUpperCase().indexOf("MAC") > -1;
+boolean isIEBrowser = browser.toUpperCase().indexOf("IE") > -1;
+boolean wasResized = resize > 0;
+if (isMacOs && isIEBrowser && wasInitialized() && wasResized) {
+    // do something
+}
+```
+
+**Difference from "Replace Temp with Query"**: Explaining variable splits when an expression is too complex; Replace Temp with Query promotes to a method when a variable is only used once.

--- a/.claude/skills/team-skill-creator/SKILL.md
+++ b/.claude/skills/team-skill-creator/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: team-skill-creator
+description: Team Skill Generator. Crystallizes a multi-agent collaboration pattern into a reusable team skill file set (SKILL.md / roles/*.md / workflow.md / bind.md / dependencies.yaml). Automatically applied when a user wants to turn a collaboration pattern into a template, create a team skill, write a specific team skill file, or reference investment-analysis-team to build a new team skill. Related keywords: team skill creator, team skill creation, crystallize collaboration, team skill template, roles/workflow/bind/dependencies. Not applicable to: single-agent problems, Java code assembly (use agent-team-guide), discussions unrelated to team skill files.
+---
+
+# Team Skill Generator
+
+This skill guides Claude in generating a complete team skill file set for the user. A team skill is a reusable collaboration template for the `com.openjiuwen.agentteams` framework, consisting of 5 types of files placed in the team workspace `skills/` or `~/.openjiuwen/workspace/skills/` for automatic discovery by the framework.
+
+## Generation Process (Must Follow This Order)
+
+1. **Gather Requirements**: Ask the user four questions (if not fully provided):
+   - What does the team do? (One-sentence goal)
+   - How many roles? What is each role called and what does it do?
+   - How do roles collaborate? (Parallel / Debate / Pipeline / Quality Gate / Hybrid)
+   - What external skills / tools does each role depend on?
+2. **Select Collaboration Pattern**: Choose 1-3 pattern combinations from "Collaboration Pattern Classification" based on the user's description.
+3. **Create Directory**: `<team-skill-name>/` with a `roles/` subdirectory.
+4. **Generate 5 File Types from Templates**: Fill in the templates below.
+5. **Focus Check on roles/*.md**: Each role file must contain an `## Inline Persona for Teammate` section (the framework does not auto-load it; the leader must read it and paste it into the dispatch prompt).
+6. **Self-Check**: Verify each item in the "Post-Generation Self-Check List".
+7. **Inform Placement Path**: Tell the user to place the generated directory under `~/.openjiuwen/workspace/skills/` or the team workspace `skills/` for the framework to discover it.
+
+## Five File Templates (With Field Annotations)
+
+When generating a team skill, use `read_file` to read the corresponding template file, fill in the placeholders, and `write_file` to the target directory. Template files contain complete field annotations and are not inlined in this SKILL.md to save context.
+
+| File to Generate | Read Template | Description |
+| --- | --- | --- |
+| `<team-skill-name>/SKILL.md` | `templates/SKILL.md` | Team metadata: name/version/kind: team-skill/roles overview |
+| `<team-skill-name>/roles/<role>.md` | `templates/role.md` | Role definition: Identity/Success Criteria/Boundary/Output Schema/Inline Persona |
+| `<team-skill-name>/workflow.md` | `templates/workflow.md` | Execution script: flowchart + Step 0~N + Final Report |
+| `<team-skill-name>/bind.md` | `templates/bind.md` | Constraints: Resource Constraints/Behavioral Constraints/Failure Handling |
+| `<team-skill-name>/dependencies.yaml` | `templates/dependencies.yaml` | Dependencies: skills/tools/global_dependencies |
+
+**Key Reminder**: The `## Inline Persona for Teammate` section in `roles/*.md` is what the leader must `read_file` and paste into the dispatch prompt before `spawn_member` -- the framework does not auto-load it; the leader must explicitly read it. This section in the template is wrapped with ` ``` ` (not ` ```markdown `) to avoid nested code block errors when the leader extracts it.
+
+## Collaboration Pattern Classification (Choose 1-3 Combinations)
+
+Select patterns based on the user's description, which determines the workflow structure and bind constraints:
+
+| Pattern | Characteristics | Workflow Structure | Key Bind Constraints |
+|---|---|---|---|
+| **Parallel Decomposition** | Multiple roles analyze different dimensions simultaneously, invisible to each other | Parallel spawn → each outputs report → leader consolidates | `max_parallel_teammates` / analysts invisible to each other |
+| **Adversarial Debate** | Two opposing roles exchange views directly point-to-point | Round 1 independent → Round 2 direct debate → output conclusion | `debate_rounds_limit` / `min_debate_rounds` / direct point-to-point > leader forwarding |
+| **Pipeline** | Upstream output is automatically delivered to downstream (via dependencies) | T1 → T2 → T3 with dependencies | Use `create_task(dependencies=[...])` / `member_results_delivery` for auto-delivery |
+| **Quality Gate** | Leader verifies quality after upstream completes before downstream starts | Upstream → Quality check → Downstream | Quality gate failure loops back / `max_retry_per_step` |
+| **Hybrid** | Combination of the above (e.g., investment-analysis-team = parallel + debate + pipeline) | Multi-Step combination | Multiple constraints, write visibility rules per phase |
+
+**Pattern Selection Tips**:
+- User says "several roles analyze different aspects simultaneously" → Parallel Decomposition
+- User says "pro vs con / optimistic vs pessimistic / support vs oppose" → Adversarial Debate
+- User says "upstream finishes then downstream continues" → Pipeline
+- User says "must check quality before continuing" → Quality Gate
+- User says "both parallel and debate" → Hybrid
+
+## Minimal Complete Example (2-Role Parallel)
+
+User says "I want a team: one writes code, one writes tests, both work in parallel." The generated minimal team skill:
+
+### `<team-skill-name>/SKILL.md`
+
+```yaml
+---
+name: dev-test-parallel
+version: "1.0"
+kind: team-skill
+roles:
+  - id: developer
+    purpose: "Implement functional code as described by the user"
+    skills: []
+    tools: [python3]
+  - id: tester
+    purpose: "Write test cases for the functional code"
+    skills: []
+    tools: [python3]
+---
+
+# Dev-Test Parallel Team
+
+Two people in parallel: developer implements code, tester writes tests, invisible to each other, leader consolidates both outputs at the end.
+
+## Workflow
+
+1. **Pre-flight** — Check python3 availability
+2. **Parallel Execution** — developer writes code, tester writes tests
+3. **Final Report** — leader consolidates both outputs
+
+## Role Responsibilities
+
+| Role | Responsibility | Output |
+| --- | --- | --- |
+| developer | Implement functional code | .team/reports/T1_developer.md |
+| tester | Write test cases | .team/reports/T2_tester.md |
+```
+
+### `<team-skill-name>/roles/developer.md`
+
+```markdown
+# Role: Developer
+
+## Identity
+
+> *"I am the feature implementer, writing runnable code based on the user's description."*
+
+Responsible for translating user requirements into code implementations.
+
+## Success Criteria
+
+- Code meets all functional points described by the user
+- Code runs without syntax errors
+
+## Boundary
+
+**Forbidden**:
+- Do NOT write tests (this is the tester's responsibility)
+
+**Mandatory**:
+- You MUST output complete runnable code
+
+## Output Schema
+
+\`\`\`markdown
+## Role: Developer
+
+### Feature Implementation
+<code block>
+
+### Implementation Notes
+<key decision points>
+\`\`\`
+
+## Inline Persona for Teammate
+
+\`\`\`
+ROLE: Developer in a Teamskill.
+
+You are the feature implementer, writing runnable code based on the user's description.
+
+You MUST output complete runnable code.
+You MUST NOT write tests.
+
+INPUTS YOU WILL RECEIVE:
+- Feature description: {FEATURE_DESC_PLACEHOLDER}
+
+PROCESSING INSTRUCTIONS:
+1. Analyze the feature description
+2. Implement the code
+3. Write to .team/reports/T1_developer.md
+4. send_message to leader with file path and summary
+
+OUTPUT:
+- Write to file: .team/reports/T1_developer.md
+\`\`\`
+```
+
+### `<team-skill-name>/roles/tester.md`
+
+Full version see `references/dev_test_parallel/roles/tester.md` (persona changed to "I am the test engineer, writing test cases for the functional code", forbidden to "implement functional code").
+
+### `<team-skill-name>/workflow.md`
+
+```markdown
+# Workflow: Dev-Test Parallel Team
+
+## Flowchart
+
+\`\`\`mermaid
+graph TD
+    S0[Step 0 Pre-flight] --> S1[Step 1 Parallel Execution]
+    S1 --> Final[Final Report]
+\`\`\`
+
+## Step 0: Pre-flight
+
+- **Executor**: leader
+- **Action**: Check python3 availability
+- **Quality Gate**: python3 available
+
+## Step 1: Parallel Execution
+
+- **Executor**: developer + tester (parallel)
+- **Input**: User feature description
+- **Output**: .team/reports/T1_developer.md + .team/reports/T2_tester.md
+- **Quality Gate**: Both files exist
+
+## Final Report
+
+leader consolidates into .team/reports/T3_final_report.md, quoting both outputs verbatim.
+```
+
+### `<team-skill-name>/bind.md`
+
+```markdown
+# Bind: Dev-Test Parallel Team Constraints
+
+## Resource Constraints
+
+| Constraint | Limit | Description |
+|---|---|---|
+| `max_parallel_teammates` | 2 | Two people in parallel |
+| `total_wall_clock_budget` | 10 minutes | Maximum execution time |
+| `per_role_token_limit` | 8000 tokens | Per-person token limit |
+
+## Behavioral Constraints
+
+1. **Leader does not generate content**: Leader is only responsible for task distribution and report consolidation
+2. **developer and tester are invisible to each other**: Cannot see each other's output during parallel work
+
+## Failure Handling
+
+| Failure Scenario | Handling |
+|---|---|
+| One party fails | Retry 2 times; if still fails, leader reports the failure point |
+```
+
+### `<team-skill-name>/dependencies.yaml`
+
+```yaml
+# Dependencies: Dev-Test Parallel Team
+
+skills: []
+
+tools:
+  - name: python3
+    source: local
+    required: true
+    purpose: "Run code and tests"
+    roles:
+      - developer
+      - tester
+
+global_dependencies:
+  description: "Only python3 needed"
+  fallback_mode: "Cannot run without python3"
+```
+
+## Post-Generation Self-Check List (Required)
+
+After generating the 5 file types, verify each item:
+
+- [ ] `SKILL.md` frontmatter contains `kind: team-skill` + `roles` overview
+- [ ] Each `.md` filename under `roles/` matches the `id` in `SKILL.md`
+- [ ] Each `roles/*.md` contains all five sections: `## Identity` / `## Success Criteria` / `## Boundary` / `## Output Schema` / `## Inline Persona for Teammate`
+- [ ] `## Inline Persona for Teammate` section is wrapped with ` ``` ` (not nested markdown code block), containing `ROLE:` / `You MUST` / `INPUTS YOU WILL RECEIVE` / `PROCESSING INSTRUCTIONS` / `OUTPUT` sub-sections
+- [ ] `workflow.md` has Step numbering + `Executor` / `Input` / `Output` / `Quality Gate` for each step
+- [ ] `bind.md` contains all three sections: `Resource Constraints` / `Behavioral Constraints` / `Failure Handling`
+- [ ] `dependencies.yaml` items with `required: false` can degrade gracefully when missing
+- [ ] Output file paths consistently use `.team/reports/T<sequence>_<role>_<output>.md` format
+- [ ] Inter-role visibility rules match the collaboration pattern (parallel = invisible to each other, debate Round 2 = directly visible)
+- [ ] Inform user of placement path: `~/.openjiuwen/workspace/skills/` or team workspace `skills/`
+
+## Usage
+
+1. **Gather Requirements**: Proactively ask when the user hasn't provided all 4 questions.
+2. **Select Pattern**: Choose 1-3 combinations from "Collaboration Pattern Classification".
+3. **Apply Templates**: All 5 file type templates are in this skill; fill in the blanks per annotations.
+4. **Reference Minimal Example**: The complete 2-role parallel example is above; expand for complex scenarios following the same pattern.
+5. **Self-Check**: Verify each item in the "Post-Generation Self-Check List", especially the `## Inline Persona for Teammate` section.
+6. **Inform Placement**: After generation, tell the user to place the directory under `~/.openjiuwen/workspace/skills/` or the team workspace `skills/`.
+
+## Reference Entry Points
+
+- Complete team skill example: `examples/agent_teams/skills/investment-analysis-team/` (8-role hybrid pattern)
+- **Minimal complete reference sample**: `references/dev_test_parallel/` (2-role parallel, all 5 files in full version; read this directory for comparison when generating new team skills)
+- Framework usage guide: `resources/skills/agent-team-guide/SKILL.md`
+- Full documentation: `documents/zh/2.开发指南/多智能体/AgentTeams.md` "Team Skill" section

--- a/.claude/skills/team-skill-creator/references/dev_test_parallel/SKILL.md
+++ b/.claude/skills/team-skill-creator/references/dev_test_parallel/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: dev-test-parallel
+version: "1.0"
+kind: team-skill
+roles:
+  - id: developer
+    purpose: "Implement functional code as described by the user"
+    skills: []
+    tools: [python3]
+  - id: tester
+    purpose: "Write test cases for the functional code"
+    skills: []
+    tools: [python3]
+---
+
+# Dev-Test Parallel Team
+
+Two people in parallel: developer implements code, tester writes tests, invisible to each other, leader consolidates both outputs at the end. This is the **minimal example of the Parallel Decomposition pattern**, used as a reference sample when team-skill-creator generates new team skills.
+
+## Workflow
+
+The team follows this workflow (see [workflow.md](workflow.md) for details):
+
+1. **Pre-flight** — Check python3 availability
+2. **Parallel Execution** — developer writes code, tester writes tests, invisible to each other
+3. **Final Report** — leader consolidates both outputs
+
+## Role Responsibilities
+
+| Role | Responsibility | Output |
+| --- | --- | --- |
+| developer | Implement functional code | .team/reports/T1_developer.md |
+| tester | Write test cases | .team/reports/T2_tester.md |
+
+## File List
+
+- `SKILL.md` — This file, team metadata
+- `roles/developer.md` — Developer role definition (with inline persona)
+- `roles/tester.md` — Test engineer role definition (with inline persona)
+- `workflow.md` — Complete execution script
+- `bind.md` — Resource constraints and failure handling
+- `dependencies.yaml` — External dependency declarations

--- a/.claude/skills/team-skill-creator/references/dev_test_parallel/bind.md
+++ b/.claude/skills/team-skill-creator/references/dev_test_parallel/bind.md
@@ -1,0 +1,42 @@
+# Bind: Dev-Test Parallel Team Constraints and Failure Handling
+
+## Resource Constraints
+
+| Constraint | Limit | Description |
+|---|---|---|
+| `max_parallel_teammates` | 2 | Two people in parallel |
+| `total_wall_clock_budget` | 10 minutes | Maximum execution time for the entire process |
+| `total_token_budget` | 16,000 tokens | Maximum token consumption for the entire process |
+| `per_role_token_limit` | 8,000 tokens | Maximum token consumption per role |
+| `max_retry_per_step` | 2 | Maximum 2 retries per step |
+
+### Per-role asymmetric limits
+
+| Role | Token Limit | Time Limit | Special Constraint |
+|---|---|---|---|
+| developer | 8,000 | 5 minutes | Must output complete runnable code |
+| tester | 8,000 | 5 minutes | Must include boundary cases and exception paths |
+
+## Behavioral Constraints
+
+### Team-level rules
+
+1. **Leader does not generate content**: Leader is only responsible for task distribution and report consolidation; does not write code or tests
+2. **developer and tester are invisible to each other**: Cannot see each other's output during parallel work
+3. **No cross-modification**: tester cannot modify developer's code, developer cannot modify tests
+
+### Phase-scoped visibility rules
+
+| Phase | Visibility | Description |
+|---|---|---|
+| Step 1 (Parallel Execution) | Fully isolated | developer and tester cannot see each other's output |
+| Final Report | Leader visible | leader sees both outputs and consolidates them |
+
+## Failure Handling
+
+| Failure Scenario | Handling Strategy |
+|---|---|
+| developer fails | Retry 2; if still fails, leader reports the failure point; tester can still write tests based on the failure information |
+| tester fails | Retry 2; if still fails, leader only consolidates developer output, noting test absence |
+| python3 unavailable | Terminate (required: true) |
+| Timeout | Force-end current step; leader reports completed portions |

--- a/.claude/skills/team-skill-creator/references/dev_test_parallel/dependencies.yaml
+++ b/.claude/skills/team-skill-creator/references/dev_test_parallel/dependencies.yaml
@@ -1,0 +1,18 @@
+# Dependencies: Dev-Test Parallel Team Dependency Configuration
+
+skills: []  # This team does not depend on external skills, pure code generation
+
+tools:
+  - name: python3
+    source: local
+    required: true
+    purpose: "Run functional code and test code"
+    roles:
+      - developer
+      - tester
+
+# Global dependency notes
+global_dependencies:
+  description: "This team only needs python3 to run, no external skill dependencies"
+  fallback_mode: "If python3 is unavailable, the team cannot run (required: true)"
+  community_enrichment: "Optional: find code review, formatting, etc. skills from the community to enhance leader's consolidation capability"

--- a/.claude/skills/team-skill-creator/references/dev_test_parallel/roles/developer.md
+++ b/.claude/skills/team-skill-creator/references/dev_test_parallel/roles/developer.md
@@ -1,0 +1,65 @@
+# Role: Developer
+
+## Identity
+
+> *"I am the feature implementer, writing runnable code based on the user's description."*
+
+Responsible for translating user requirements into code implementations. Focused on code runnability, functional completeness, and implementation simplicity.
+
+## Success Criteria
+
+- Code meets all functional points described by the user
+- Code runs without syntax errors
+- Output includes implementation notes (key decision points)
+
+**Focus areas**: Feature implementation, code structure, runnability.
+
+## Boundary
+
+**Forbidden** (prevent role overlap):
+- Do NOT write test cases (this is the tester's responsibility)
+- Do NOT perform code review or quality assessment (this is the leader's responsibility)
+
+**Mandatory**:
+- You MUST output complete runnable code
+- You MUST list key decision points in the implementation notes
+
+## Output Schema
+
+```markdown
+## Role: Developer
+
+### Feature Implementation
+<code block with complete runnable code>
+
+### Implementation Notes
+- <key decision point 1>
+- <key decision point 2>
+```
+
+## Inline Persona for Teammate
+
+```
+ROLE: Developer in a Teamskill.
+
+You are the feature implementer, writing runnable code based on the user's description. Your default mode is direct implementation, prioritizing code runnability and functional completeness.
+
+You MUST output complete runnable code.
+You MUST list key decision points in the implementation notes.
+You MUST NOT write test cases.
+You MUST NOT perform code review.
+
+INPUTS YOU WILL RECEIVE:
+- Feature description: {FEATURE_DESC_PLACEHOLDER}
+
+PROCESSING INSTRUCTIONS:
+1. Analyze the feature description, list the functional points to implement
+2. Implement the code
+3. Write implementation notes (key decision points)
+4. Write to file .team/reports/T1_developer.md
+5. send_message to leader with file path and summary (do not send full code)
+
+OUTPUT:
+- Write to file: .team/reports/T1_developer.md
+- After completion, send_message to leader with file path and summary
+```

--- a/.claude/skills/team-skill-creator/references/dev_test_parallel/roles/tester.md
+++ b/.claude/skills/team-skill-creator/references/dev_test_parallel/roles/tester.md
@@ -1,0 +1,69 @@
+# Role: Test Engineer (Tester)
+
+## Identity
+
+> *"I am the quality guardian, writing comprehensive test cases for the functional code."*
+
+Responsible for writing test cases for the code implemented by the developer. Focused on test coverage, boundary cases, and exception paths.
+
+## Success Criteria
+
+- Test cases cover all functional points
+- Include at least 2 boundary cases
+- Include at least 1 exception path case
+
+**Focus areas**: Test coverage, boundary cases, exception paths, test runnability.
+
+## Boundary
+
+**Forbidden** (prevent role overlap):
+- Do NOT implement functional code (this is the developer's responsibility)
+- Do NOT modify the developer's code
+
+**Mandatory**:
+- You MUST output runnable test code
+- You MUST include boundary cases and exception paths
+
+## Output Schema
+
+```markdown
+## Role: Test Engineer
+
+### Test Cases
+<test code block with complete runnable tests>
+
+### Coverage Notes
+- <functional point 1>: <case number>
+- <functional point 2>: <case number>
+- Boundary cases: <list>
+- Exception paths: <list>
+```
+
+## Inline Persona for Teammate
+
+```
+ROLE: Test Engineer in a Teamskill.
+
+You are the quality guardian, writing comprehensive test cases for the functional code. Your default mode is critical, prioritizing finding boundary and exception cases.
+
+You MUST output runnable test code.
+You MUST include at least 2 boundary cases.
+You MUST include at least 1 exception path case.
+You MUST NOT implement functional code.
+You MUST NOT modify the developer's code.
+
+INPUTS YOU WILL RECEIVE:
+- Feature description: {FEATURE_DESC_PLACEHOLDER}
+
+PROCESSING INSTRUCTIONS:
+1. Analyze the feature description, list the functional points to test
+2. Design test cases (normal + boundary + exception)
+3. Write test code
+4. Write coverage notes
+5. Write to file .team/reports/T2_tester.md
+6. send_message to leader with file path and summary
+
+OUTPUT:
+- Write to file: .team/reports/T2_tester.md
+- After completion, send_message to leader with file path and summary
+```

--- a/.claude/skills/team-skill-creator/references/dev_test_parallel/workflow.md
+++ b/.claude/skills/team-skill-creator/references/dev_test_parallel/workflow.md
@@ -1,0 +1,44 @@
+# Workflow: Dev-Test Parallel Team
+
+## Flowchart
+
+```mermaid
+graph TD
+    S0[Step 0 Pre-flight] --> S1[Step 1 Parallel Execution]
+    S1 --> Final[Final Report]
+```
+
+## Step 0: Pre-flight Dependency Check
+
+- **Executor**: leader
+- **Action**: Read [dependencies.yaml](dependencies.yaml), verify python3 availability
+- **Output**: Report dependency status; terminate if python3 is missing (required: true)
+- **Quality Gate**: python3 available, user confirms to continue
+
+## Step 1: Parallel Execution
+
+- **Executor**: developer + tester (parallel spawn)
+- **Input**: User feature description
+- **Output**:
+  - developer → `.team/reports/T1_developer.md`
+  - tester → `.team/reports/T2_tester.md`
+- **Visibility**: developer and tester are invisible to each other (parallel decomposition pattern)
+- **Quality Gate**: Both files exist and contain complete code blocks
+
+## Final Report
+
+leader consolidates both outputs into `.team/reports/T3_final_report.md` using **verbatim quoting**:
+
+```markdown
+# Dev-Test Parallel Team Final Report
+
+## Developer Output
+<Verbatim quote of .team/reports/T1_developer.md content>
+
+## Test Engineer Output
+<Verbatim quote of .team/reports/T2_tester.md content>
+
+## Consolidation Notes
+- Correspondence between code and tests
+- Suggested next steps (e.g., run tests, fix failing cases)
+```

--- a/.claude/skills/team-skill-creator/templates/SKILL.md
+++ b/.claude/skills/team-skill-creator/templates/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: <team-skill-name>          # Team skill name, kebab-case, matches directory name
+version: "1.0"                   # Version number
+kind: team-skill                 # Fixed value, identifies this as a team skill
+roles:                           # Role overview, leader reads this during ReAct for orchestration
+  - id: <role-1>                 # Role id, kebab-case, matches roles/<role-1>.md filename
+    purpose: "<one-sentence responsibility>"       # What this role does
+    skills: [<skill-name>]       # External skills this role depends on; empty array means pure reasoning
+    tools: [<tool-name>]         # Tools this role needs, e.g., python3/curl/jq
+  - id: <role-2>
+    purpose: "<one-sentence responsibility>"
+    skills: []
+    tools: []
+---
+
+# <Team Name>
+
+<2-3 sentences describing what the team does, what collaboration pattern it uses, and what problem it solves.>
+
+## Workflow
+
+The team follows this workflow (see [workflow.md](workflow.md) for details):
+
+1. **<Step Name>** — <One sentence>
+2. **<Step Name>** — <One sentence>
+...
+
+## Role Responsibilities
+
+| Role | Responsibility | Output |
+| --- | --- | --- |
+| <role-1> | <responsibility> | <output file or content> |
+| <role-2> | <responsibility> | <output file or content> |
+
+## File List
+
+- `SKILL.md` — This file, team metadata
+- `roles/*.md` — Role definitions (with inline persona)
+- `workflow.md` — Complete execution script
+- `bind.md` — Resource constraints and failure handling
+- `dependencies.yaml` — External dependency declarations

--- a/.claude/skills/team-skill-creator/templates/bind.md
+++ b/.claude/skills/team-skill-creator/templates/bind.md
@@ -1,0 +1,42 @@
+# Bind: <Team Name> Constraints and Failure Handling
+
+## Resource Constraints
+
+| Constraint | Limit | Description |
+|---|---|---|
+| `max_parallel_teammates` | <N> | Maximum <N> teammates in parallel |
+| `total_wall_clock_budget` | <N> minutes | Maximum execution time for the entire process |
+| `total_token_budget` | <N> tokens | Maximum token consumption for the entire process |
+| `per_role_token_limit` | <N> tokens | Maximum token consumption per role |
+| `max_retry_per_step` | 2 | Maximum 2 retries per step |
+
+### Per-role asymmetric limits
+
+| Role | Token Limit | Time Limit | Special Constraint |
+|---|---|---|---|
+| <role-1> | <N> | <N> minutes | <special requirement> |
+| <role-2> | <N> | <N> minutes | <special requirement> |
+
+## Behavioral Constraints
+
+### Team-level rules
+
+1. **Leader does not generate content**: Leader is only responsible for task distribution, quality gating, and report consolidation
+2. **<Visibility rule 1>**: <description>
+3. **<Visibility rule 2>**: <description>
+
+### Phase-scoped visibility rules
+
+| Phase | Visibility | Description |
+|---|---|---|
+| Step <N> | <Fully isolated / Directly visible / Leader visible> | <description> |
+
+## Failure Handling
+
+| Failure Scenario | Handling Strategy |
+|---|---|
+| Teammate execution fails | Retry 2; if still fails, degrade or skip |
+| Input overload | Truncate + prompt, continue execution |
+| Quality gate fails | Loop back to upstream role for redo |
+| Debate fails | Fallback: each outputs independent conclusion |
+| Complete failure | Output error report, marking failure points |

--- a/.claude/skills/team-skill-creator/templates/dependencies.yaml
+++ b/.claude/skills/team-skill-creator/templates/dependencies.yaml
@@ -1,0 +1,24 @@
+# Dependencies: <Team Name> Dependency Configuration
+
+skills:
+  - name: <skill-name>           # External skill name
+    source: local                # Source
+    required: false              # false means degrade when missing, true means required
+    purpose: "<what this skill does>"
+    roles:                       # Which roles use it
+      - <role-name>
+
+tools:
+  - name: python3
+    source: local
+    required: true               # Tools are generally required: true
+    purpose: "<purpose>"
+    roles:
+      - <role-1>
+      - <role-2>
+
+# Global dependency notes
+global_dependencies:
+  description: "<overall team dependency description>"
+  fallback_mode: "<degradation mode when dependencies are missing>"
+  community_enrichment: "<suggested community skills to find>"

--- a/.claude/skills/team-skill-creator/templates/role.md
+++ b/.claude/skills/team-skill-creator/templates/role.md
@@ -1,0 +1,62 @@
+# Role: <Role Name>
+
+## Identity
+
+> *"<One-sentence persona motto>"*
+
+<2-3 sentences describing this role's identity, methodology, and focus areas.>
+
+## Success Criteria
+
+- <Quantifiable completion criterion 1>
+- <Quantifiable completion criterion 2>
+- <Quantifiable completion criterion 3>
+
+**Focus areas**: <list of focus areas>
+
+## Boundary
+
+**Forbidden** (prevent role overlap):
+- Do NOT <other role's responsibility 1>
+- Do NOT <other role's responsibility 2>
+
+**Mandatory**:
+- You MUST <required action 1>
+- You MUST <required action 2>
+
+## Output Schema
+
+```markdown
+## Role: <Role Name>
+
+### <Output Dimension 1>
+- [Metric] [Value] [Analysis]
+
+### <Output Dimension 2>
+- [Conclusion] [Basis]
+```
+
+## Inline Persona for Teammate
+
+```
+ROLE: <Role Name> in a Teamskill.
+
+<2-3 sentence persona description>
+
+You MUST <required action 1>.
+You MUST <required action 2>.
+You MUST NOT <forbidden action 1>.
+
+INPUTS YOU WILL RECEIVE:
+- <Input field 1>: {<PLACEHOLDER>}
+- <Input field 2>: {<PLACEHOLDER>}
+
+PROCESSING INSTRUCTIONS:
+1. <Processing step 1>
+2. <Processing step 2>
+3. <Processing step 3>
+
+OUTPUT:
+- Write to file: .team/reports/<T*_>_<role>_<output>.md
+- After completion, send_message to leader with file path and summary (do not send full content)
+```

--- a/.claude/skills/team-skill-creator/templates/workflow.md
+++ b/.claude/skills/team-skill-creator/templates/workflow.md
@@ -1,0 +1,48 @@
+# Workflow: <Team Name>
+
+## Flowchart
+
+```mermaid
+graph TD
+    S0[Step 0 Pre-flight] --> S1[Step 1 <Name>]
+    S1 --> S2[Step 2 <Name>]
+    S2 --> S3[Step 3 <Name>]
+    S3 --> Final[Final Report]
+```
+
+## Step 0: Pre-flight Dependency Check
+
+- **Executor**: leader
+- **Action**: Read dependencies.yaml, verify dependency availability
+- **Output**: Report missing items; terminate if required=true is missing, degrade if required=false is missing
+- **Quality Gate**: User confirms whether to continue
+
+## Step 1: <Step Name>
+
+- **Executor**: <leader / role-name>
+- **Input**: <input source>
+- **Output**: <output file path>
+- **Quality Gate**: <completion verification criteria>
+
+## Step 2: <Step Name>
+
+- **Executor**: <role-name>
+- **Input**: <upstream output / user input>
+- **Output**: <output file path>
+- **Quality Gate**: <completion verification criteria>
+
+## Final Report
+
+leader consolidates all intermediate reports into `.team/reports/T<last>_final_report.md` using **verbatim quoting**, template:
+
+```markdown
+# <Team Name> Final Report
+
+## Original Outputs from Each Role
+
+### <role-1> Report
+<Verbatim quote of .team/reports/T*_*.md content>
+
+### <role-2> Report
+<Verbatim quote>
+```

--- a/.claude/skills/workflow-guide/SKILL.md
+++ b/.claude/skills/workflow-guide/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: workflow-guide
+description: Workflow application building guide. Based on the com.openjiuwen.core.workflow package, guides users to build, orchestrate, and execute a single workflow graph from scratch, as well as host multiple workflows with WorkflowAgent. Actively apply when users build workflows, use Workflow/WorkflowCard/WorkflowSessions, register Start/End/LLMComponent/QuestionerComponent, connect edges with addConnection/addConditionalConnection/addStreamConnection, call invoke/stream, handle INPUT_REQUIRED interactive input, or do WorkflowAgent multi-workflow routing. Related keywords: workflow, WorkflowCard, WorkflowSessions, WorkflowOutput, invoke, stream, QuestionerComponent, LLMComponent, addConnection, INPUT_REQUIRED, WorkflowAgent, SubWorkflowComponentImpl. Not applicable for: agent team assembly (use agent-team-guide), single ReAct agent, discussions unrelated to workflow.
+---
+
+# Workflow Application Building Guide
+
+This skill guides building workflow applications based on the `com.openjiuwen.core.workflow` package. Core mental model: **a workflow = an executable graph composed of nodes and edges**, executed in batch with `invoke(...)` or in streaming mode with `stream(...)`.
+
+## Core Mental Model
+
+- `Workflow` is "an executable graph", not a workflow list, not an intent router.
+- `WorkflowAgent` is the application-layer entry point that hosts multiple workflows and selects which one to run; `Workflow` is a single graph.
+- Registering components defines "what the nodes are"; connecting edges defines "what path the nodes execute along". **Both are required**.
+- `invoke(...)` focuses on complete results; `stream(...)` focuses on incremental output.
+- `INPUT_REQUIRED` is not a failure; it is an intermediate state meaning "waiting for additional input", and execution resumes by reusing the same session.
+
+## Key Concepts Quick Reference
+
+| Term | Java Type | Meaning |
+| --- | --- | --- |
+| Workflow | `Workflow` | The main workflow class exposed to users; a directed graph |
+| Workflow Card | `WorkflowCard` | Metadata: id/name/version/description/inputParams |
+| Start/End Nodes | `Start` / `End` | Entry node passes through input / Exit node produces final result |
+| Business Nodes | `QuestionerComponent` / `LLMComponent` / `BranchComponent` / `IntentDetectionComponent` | Actual business logic |
+| Sub-Workflow | `SubWorkflowComponentImpl` | Wraps another Workflow as a node call |
+| Normal Edge | `addConnection(...)` | Batch sequential dependency |
+| Conditional Edge | `addConditionalConnection(...)` | Runtime decision for next node (`BranchRouter` or `Function`) |
+| Streaming Edge | `addStreamConnection(...)` | Passes incremental data |
+| Workflow Session | `WorkflowSessions` / `WorkflowSessionApi` | Saves execution state, shares intermediate results, handles interactive resumption |
+| Workflow Output | `WorkflowOutput` | Return container from `invoke(...)`, contains `result` + `state` |
+| Execution State | `WorkflowExecutionState` | `COMPLETED` / `INPUT_REQUIRED` / `ERROR` |
+| Streaming Chunk | `WorkflowChunk` / `OutputSchema` | Incremental data chunk returned by `stream(...)` |
+| Interactive Input | `InteractiveInput` | Input submitted to resume execution after `INPUT_REQUIRED` |
+| Application Entry | `WorkflowAgent` | Hosts multiple workflows, performs intent recognition and routing |
+
+## Scenario Quick Reference
+
+Locate the corresponding section in this skill by task scenario:
+
+| Scenario | Go To |
+| --- | --- |
+| Build a minimal workflow from scratch | "Quick Start: Minimal Workflow" |
+| Build a streaming workflow | "Quick Start: Streaming Workflow" |
+| Handle follow-up questions / interactive input | "INPUT_REQUIRED and Interactive Resumption" |
+| Choose invoke vs stream | "invoke vs stream" |
+| Implement conditional branching / loops | "Conditional Edges and Routing" |
+| Nest sub-workflows | "Sub-Workflow" |
+| Host multiple workflows | "WorkflowAgent Multi-Workflow Routing" |
+| Choose component ability type | "Component Ability Types (INVOKE/STREAM/COLLECT/TRANSFORM)" |
+| Understand schema reference expressions | "Schema Reference Syntax" |
+| Troubleshoot workflow not executing | "Pitfall FAQ" |
+
+## Quick Start: Minimal Workflow
+
+Minimal example: `Start -> QuestionerComponent -> End`, demonstrating follow-up questioning + execution resumption.
+
+```java
+import com.openjiuwen.core.workflow.Workflow;
+import com.openjiuwen.core.workflow.WorkflowCard;
+import com.openjiuwen.core.workflow.WorkflowExecutionState;
+import com.openjiuwen.core.workflow.WorkflowOutput;
+import com.openjiuwen.core.workflow.WorkflowSessions;
+import com.openjiuwen.core.workflow.component.End;
+import com.openjiuwen.core.workflow.component.Start;
+import com.openjiuwen.core.workflow.component.llm.*;
+import com.openjiuwen.core.session.WorkflowSessionApi;
+import com.openjiuwen.core.session.interaction.InteractiveInput;
+
+// 1. Define card
+WorkflowCard card = WorkflowCard.builder()
+        .id("transfer_flow")
+        .name("Transfer Service")
+        .version("1.0")
+        .description("Collect missing transfer amount and return final result")
+        .inputParams(Map.of("type", "object",
+                "properties", Map.of("query", Map.of("type", "string")),
+                "required", List.of("query")))
+        .build();
+
+// 2. Create Workflow and register nodes
+Workflow workflow = new Workflow(card);
+workflow.setStartComp("start", new Start(), Map.of("query", "${query}"), null);
+
+QuestionerConfig qConfig = new QuestionerConfig();
+qConfig.setModelClientConfig(clientConfig);
+qConfig.setModelConfig(requestConfig);
+qConfig.setQuestionContent("Please provide the transfer amount");
+qConfig.setExtractFieldsFromResponse(true);
+qConfig.setFieldNames(List.of(FieldInfo.builder()
+        .fieldName("amount").description("Transfer amount").required(true).build()));
+qConfig.setWithChatHistory(false);
+qConfig.setMaxResponse(10);
+workflow.addWorkflowComp("questioner", new QuestionerComponent(qConfig),
+        Map.of("query", "${start.query}"), null);
+
+workflow.setEndComp("end",
+        new End(Map.of("responseTemplate", "Transfer amount is {{amount}}")),
+        Map.of("amount", "${questioner.amount}"), null);
+
+// 3. Connect edges (required, cannot omit)
+workflow.addConnection("start", "questioner");
+workflow.addConnection("questioner", "end");
+
+// 4. Create session and execute
+WorkflowSessionApi session = WorkflowSessions.createWorkflowSession("conversation-001");
+WorkflowOutput output = workflow.invoke(Map.of("query", "I want to transfer"), session, null);
+
+// 5. Handle INPUT_REQUIRED
+if (WorkflowExecutionState.INPUT_REQUIRED.equals(output.getState())) {
+    InteractiveInput reply = new InteractiveInput();
+    reply.update("questioner", "2000 yuan");
+    output = workflow.invoke(reply, session, null);
+}
+
+if (WorkflowExecutionState.COMPLETED.equals(output.getState())) {
+    System.out.println(output.getResult());
+}
+```
+
+**Key Reminders**:
+- `${query}` reads from the workflow top-level input; `${start.query}` reads from Start output; `${questioner.amount}` reads from questioner output.
+- `addWorkflowComp(...)` only places nodes and **does not form execution order**; order is determined by `addConnection(...)`.
+- To resume execution, you must **reuse the same session**; switching sessions will lose previous state.
+
+## Quick Start: Streaming Workflow
+
+Connect `LLMComponent` incremental output to `End` via `addStreamConnection(...)`.
+
+```java
+LLMCompConfig llmConfig = new LLMCompConfig();
+llmConfig.setModelClientConfig(clientConfig);
+llmConfig.setModelConfig(requestConfig);
+llmConfig.setTemplateContent(List.of(
+        Map.of("role", "system", "content", "You are a concise assistant."),
+        Map.of("role", "user", "content", "{{query}}")));
+llmConfig.setResponseFormat(Map.of("type", "text"));
+llmConfig.setOutputConfig(Map.of("answer", Map.of("type", "string", "required", true)));
+
+Workflow streamWorkflow = new Workflow();
+streamWorkflow.setStartComp("start", new Start(), Map.of("query", "${query}"), null);
+streamWorkflow.addWorkflowComp("llm", new LLMComponent(llmConfig),
+        Map.of("query", "${start.query}"), null);
+
+// End uses streaming mode; the key is streamInputsSchema
+streamWorkflow.setEndComp("end",
+        new End(Map.of("responseTemplate", "{{answer}}")),
+        null, null,
+        Map.of("answer", "${llm.answer}"), null,
+        "streaming");
+
+streamWorkflow.addConnection("start", "llm");
+streamWorkflow.addStreamConnection("llm", "end");  // Streaming edge
+
+// Execute: returns synchronous Iterator
+Iterator<WorkflowChunk> chunks = streamWorkflow.stream(
+        Map.of("query", "Introduce Java workflows"),
+        WorkflowSessions.createWorkflowSession(),
+        null,
+        List.of(StreamMode.OUTPUT));
+
+while (chunks.hasNext()) {
+    WorkflowChunk chunk = chunks.next();
+    if (chunk instanceof OutputSchema output) {
+        System.out.println(output.getPayload());
+    }
+}
+```
+
+**Key Reminders**:
+- `End` in streaming mode must declare `streamInputsSchema` (the 5th parameter), not `inputsSchema`.
+- `stream(...)` returns a **synchronous Iterator**, not an async stream.
+- `StreamMode.OUTPUT` is the most common subscription mode; there are also `TRACE` / `CUSTOM`.
+
+## invoke vs stream
+
+## invoke vs stream
+
+| Invocation | Suitable Scenario | Return |
+| --- | --- | --- |
+| `invoke(...)` | Get complete result in one call; includes interactive pause and resumption | `WorkflowOutput` (result + state) |
+| `stream(...)` | Consume output incrementally while executing | `Iterator<WorkflowChunk>` |
+
+## INPUT_REQUIRED and Interactive Resumption
+
+When `QuestionerComponent` needs to ask a follow-up question, the workflow returns `INPUT_REQUIRED`:
+
+1. Read the current interaction prompt
+2. Construct `InteractiveInput`, `reply.update("component_id", "user answer")`
+3. **Reuse the same session** and call `workflow.invoke(reply, session, null)` again
+
+```java
+InteractiveInput reply = new InteractiveInput();
+reply.update("questioner", "2000 yuan");  // "questioner" must match the component id used at registration
+WorkflowOutput resumed = workflow.invoke(reply, session, null);
+```
+
+**Key**: The first parameter of `reply.update` is the **component id** (e.g., `"questioner"`), not the node type name. Switching sessions will lose previously accumulated state.
+
+## Conditional Edges and Routing
+
+Use `addConditionalConnection(...)` to implement runtime branching:
+
+```java
+// Method 1: BranchRouter
+workflow.addConditionalConnection("branch_node", new BranchRouter(...));
+
+// Method 2: Function routing
+workflow.addConditionalConnection("branch_node", (Function<Object, Object>) input -> {
+    String intent = ((Map<String, String>) input).get("intent");
+    return switch (intent) {
+        case "transfer" -> "transfer_node";
+        case "query" -> "query_node";
+        default -> "default_node";
+    };
+});
+```
+
+Suitable for: conditional branching, dynamic routing, loops or back-jump scenarios.
+
+## Sub-Workflow
+
+Use `SubWorkflowComponentImpl` to wrap another `Workflow` as a node in the current graph:
+
+```java
+Workflow subWorkflow = new Workflow(subCard);
+// ... build sub-workflow
+
+workflow.addWorkflowComp("sub", new SubWorkflowComponentImpl(subWorkflow),
+        Map.of("input", "${start.input}"), null);
+workflow.addConnection("start", "sub");
+workflow.addConnection("sub", "end");
+```
+
+Benefits: layered organization of complex processes, reusable common sub-processes, clearer visual structure.
+
+## WorkflowAgent Multi-Workflow Routing
+
+`WorkflowAgent` hosts multiple workflows at the application layer and selects which one to execute based on user intent.
+
+```java
+WorkflowAgentConfig config = WorkflowAgentConfig.builder()
+        .id("workflow_agent_java_example")
+        .description("Java multi-workflow financial assistant example")
+        .model(modelConfig)
+        .promptTemplate(List.of(Map.of("role", "system", "content", systemPrompt)))
+        .defaultResponse(DefaultResponse.builder().text(defaultText).build())
+        .build();
+
+WorkflowAgent agent = new WorkflowAgent(config);
+agent.addWorkflows(List.of(transferWorkflow, investWorkflow, balanceWorkflow));
+```
+
+**`WorkflowEventHandler` intent recognition priority**:
+1. If the input is an `InteractiveInput` with a node id -> directly resume the interrupted workflow (no LLM intent recognition)
+2. If only one workflow is configured -> go directly to that one
+3. Multiple workflows -> LLM intent recognition to select
+4. None matched -> return `defaultResponse`
+
+`defaultResponse` is important: when intent recognition does not match, return a default reply rather than forcing a wrong business flow selection.
+
+## Component Ability Types (INVOKE/STREAM/COLLECT/TRANSFORM)
+
+| Ability | Input | Output | Corresponding Method | Suitable Scenario |
+| --- | --- | --- | --- | --- |
+| `INVOKE` | batch | batch | `invoke(...)` | Normal nodes: Start, Questioner, Tool |
+| `STREAM` | batch | stream | `stream(...)` | LLM chunk-by-chunk output, ProducerNode |
+| `COLLECT` | stream | batch | `collect(...)` | Aggregate upstream multi-frame, End receives stream then returns batch |
+| `TRANSFORM` | stream | stream | `transform(...)` | Per-frame rewriting, filtering, field supplementation |
+
+**Edge Pairing**:
+- Upstream INVOKE -> Downstream INVOKE: use `addConnection`
+- Upstream STREAM/TRANSFORM -> Downstream TRANSFORM/COLLECT: use `addStreamConnection`
+
+## Schema Reference Syntax
+
+Use `${...}` in node configuration to reference other nodes' output:
+
+| Syntax | Meaning |
+| --- | --- |
+| `${query}` | Read `query` from workflow top-level input |
+| `${start.query}` | Read `query` from Start node output |
+| `${questioner.amount}` | Read `amount` from questioner node output |
+| `{{amount}}` | Render variable in End's `responseTemplate` |
+
+**Note**: `inputsSchema` only describes "where to get values" and **does not form execution order**; execution order is determined by `addConnection(...)`.
+
+## Pitfall FAQ
+
+| Symptom | Cause | Solution |
+| --- | --- | --- |
+| Workflow does not run, nodes not executing | Only `addWorkflowComp` without `addConnection` | Add `addConnection(srcId, targetId)` |
+| Resumption after `INPUT_REQUIRED` fails, state lost | Switched to a new session | Reuse the same `WorkflowSessionApi` |
+| `reply.update("Questioner", ...)` has no effect | Wrong component id (case mismatch) | id must match `addWorkflowComp("questioner", ...)` |
+| Streaming `End` receives no data | Used `inputsSchema` instead of `streamInputsSchema` | In streaming mode use the 5th parameter `streamInputsSchema` |
+| `stream(...)` hangs with no data | Did not pass `StreamMode.OUTPUT` | `stream(inputs, session, null, List.of(StreamMode.OUTPUT))` |
+| Conditional edge routing returns non-existent target id | Router return value does not match registered id | Check that the router returns a string that is a registered component id |
+| `End` output template does not render | `responseTemplate` uses undefined variable | Template variables must have their source declared in `inputsSchema` |
+| Multi-workflow routing always returns default reply | Intent recognition did not match | Check workflow `description` clarity; adjust system prompt |
+
+## Usage
+
+1. **Locate scenario**: First check "Scenario Quick Reference" to jump to the corresponding section for the current task.
+2. **Copy template**: Code blocks in the Quick Start sections can be copied and modified directly.
+3. **Understand concepts**: If terminology is unclear, check "Key Concepts Quick Reference" or Read `references/key_concepts.md`.
+4. **Component details**: When component configuration details are needed, Read `references/components_guide.md`.
+5. **Real cases**: When end-to-end reference is needed, Read `references/workflow_cases.md` (4 cases: multi-workflow financial assistant / streaming Q&A / multi-field follow-up / conditional branching).
+6. **Multi-workflow**: When multi-workflow routing is needed, see the "WorkflowAgent" section.
+7. **Troubleshoot**: First check "Pitfall FAQ", then check component ability types and schema syntax.
+8. **Do not fabricate when uncertain**: API details should be verified against source code; this skill does not replace official API documentation.
+
+## Reference Entries
+
+- **Key Concepts In-Depth**: `references/key_concepts.md` (Workflow/WorkflowCard/WorkflowSessions/WorkflowOutput/execution state/streaming chunks/InteractiveInput detailed explanation)
+- **Component Configuration Guide**: `references/components_guide.md` (Start/End/QuestionerComponent/LLMComponent/BranchComponent configuration details + 4 ability types)
+- **Real Cases**: `references/workflow_cases.md` (4 end-to-end cases: multi-workflow financial assistant / streaming Q&A / multi-field follow-up / conditional branching)
+- **Minimal Runnable Example**: `references/MinimalWorkflowExample.java` (self-contained, includes model configuration, copy and run)
+- Full documentation: `documents/zh/2.开发指南/工作流/` (overview/key concepts/building workflows/using components)
+- Example code: `examples/workflow_agent/WorkflowAgentExampleSupport.java` + `examples/interact/WeatherAssistantInteractExampleSupport.java`
+- API documentation: `documents/zh/API文档/com.openjiuwen.core/workflow/`
+- Agent team guide: `resources/skills/agent-team-guide/SKILL.md`

--- a/.claude/skills/workflow-guide/references/MinimalWorkflowExample.java
+++ b/.claude/skills/workflow-guide/references/MinimalWorkflowExample.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package references;
+
+import com.openjiuwen.core.foundation.llm.schema.ModelClientConfig;
+import com.openjiuwen.core.foundation.llm.schema.ModelRequestConfig;
+import com.openjiuwen.core.session.WorkflowSessionApi;
+import com.openjiuwen.core.session.interaction.InteractiveInput;
+import com.openjiuwen.core.workflow.Workflow;
+import com.openjiuwen.core.workflow.WorkflowCard;
+import com.openjiuwen.core.workflow.WorkflowExecutionState;
+import com.openjiuwen.core.workflow.WorkflowOutput;
+import com.openjiuwen.core.workflow.WorkflowSessions;
+import com.openjiuwen.core.workflow.component.End;
+import com.openjiuwen.core.workflow.component.Start;
+import com.openjiuwen.core.workflow.component.llm.FieldInfo;
+import com.openjiuwen.core.workflow.component.llm.QuestionerComponent;
+import com.openjiuwen.core.workflow.component.llm.QuestionerConfig;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal runnable workflow building example.
+ *
+ * Prerequisites (all required, otherwise it will not run):
+ *   1. Move this file or the entire examples/ directory under src/main/java/
+ *      so it enters the Maven compilation path.
+ *   2. Fill in real values in src/main/resources/apiconfig.json
+ *      (API_BASE / API_KEY / MODEL_PROVIDER / MODEL_NAME).
+ *      You can also override via -Dopenjiuwen.example.config=<path>
+ *      or the OPENJIUWEN_API_CONFIG environment variable.
+ *
+ * Run command:
+ *   mvn exec:java -Dexec.mainClass=references.MinimalWorkflowExample
+ *
+ * Or right-click the main method in your IDE to run directly.
+ *
+ * This example aligns with the single-workflow path in
+ * examples/workflow_agent/WorkflowAgentExampleSupport.java,
+ * but removes WorkflowAgent hosting, multi-workflow routing,
+ * console interaction loop, and other distracting logic,
+ * keeping only the main line of "define card -> register nodes ->
+ * connect edges -> invoke -> handle INPUT_REQUIRED -> finish",
+ * making it easy for beginners to understand the minimal runnable
+ * form of a single workflow.
+ *
+ * Workflow graph:
+ *   Start -> QuestionerComponent(ask for amount) -> End
+ *
+ * Execution flow:
+ *   1. User inputs "I want to transfer" (amount missing)
+ *   2. Start -> Questioner: amount missing, returns INPUT_REQUIRED
+ *   3. Code auto-replies "2000 yuan" -> resume in same session
+ *   4. Questioner extracts amount -> End -> COMPLETED
+ *   5. Output "Transfer service completed, amount is 2000 yuan."
+ */
+public final class MinimalWorkflowExample {
+
+    private MinimalWorkflowExample() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        // 1. Model configuration (in real projects, typically use SharedExampleApiConfigLoader to read apiconfig.json)
+        ModelClientConfig clientConfig = createModelClientConfig();
+        ModelRequestConfig requestConfig = createModelRequestConfig();
+
+        // 2. Define WorkflowCard (workflow identity and input schema)
+        WorkflowCard card = WorkflowCard.builder()
+                .id("transfer_flow")
+                .name("Transfer Service")
+                .version("1.0")
+                .description("Collect missing transfer amount and return final result")
+                .inputParams(Map.of(
+                        "type", "object",
+                        "properties", Map.of(
+                                "query", Map.of("type", "string", "description", "User input")
+                        ),
+                        "required", List.of("query")
+                ))
+                .build();
+
+        // 3. Create Workflow and register nodes
+        Workflow workflow = new Workflow(card);
+
+        // 3.1 Start node: pass through top-level input
+        workflow.setStartComp(
+                "start",
+                new Start(),
+                Map.of("query", "${query}"),   // ${query} reads from top-level input
+                null
+        );
+
+        // 3.2 QuestionerComponent: ask follow-up for missing amount field
+        QuestionerConfig questionerConfig = new QuestionerConfig();
+        questionerConfig.setModelClientConfig(clientConfig);
+        questionerConfig.setModelConfig(requestConfig);
+        questionerConfig.setQuestionContent("Please provide the transfer amount. It must be a number or an amount description with a currency unit.");
+        questionerConfig.setExtractFieldsFromResponse(true);
+        questionerConfig.setFieldNames(List.of(
+                FieldInfo.builder()
+                        .fieldName("amount")
+                        .description("Transfer amount, must be a number or an amount description with a currency unit.")
+                        .required(true)
+                        .build()
+        ));
+        questionerConfig.setWithChatHistory(false);
+        questionerConfig.setMaxResponse(10);
+
+        workflow.addWorkflowComp(
+                "questioner",                                       // Component id, must be consistent when resuming interaction
+                new QuestionerComponent(questionerConfig),
+                Map.of("query", "${start.query}"),                  // ${start.query} reads from Start output
+                null
+        );
+
+        // 3.3 End node: render final output using responseTemplate
+        workflow.setEndComp(
+                "end",
+                new End(Map.of("responseTemplate", "Transfer service completed, recorded transfer amount is {{amount}}.")),
+                Map.of("amount", "${questioner.amount}"),           // ${questioner.amount} reads from questioner output
+                null
+        );
+
+        // 4. Connect edges (registering nodes does not form execution order; edges must be connected)
+        workflow.addConnection("start", "questioner");
+        workflow.addConnection("questioner", "end");
+
+        // 5. Create session and execute
+        //    Note: When resuming execution, you must reuse the same session;
+        //    switching sessions will lose state
+        WorkflowSessionApi session = WorkflowSessions.createWorkflowSession("conversation-001");
+
+        // 6. First invoke: user inputs "I want to transfer" (amount missing)
+        String userQuery = args.length > 0 ? args[0] : "I want to transfer";
+        System.out.println(">>> User input: " + userQuery);
+
+        WorkflowOutput output = workflow.invoke(
+                Map.of("query", userQuery),
+                session,
+                null
+        );
+
+        // 7. Handle INPUT_REQUIRED: Questioner asks for the amount
+        if (WorkflowExecutionState.INPUT_REQUIRED.equals(output.getState())) {
+            System.out.println(">>> Workflow requires additional input (state=INPUT_REQUIRED)");
+
+            String reply = args.length > 1 ? args[1] : "2000 yuan";
+            System.out.println(">>> Reply: " + reply);
+
+            InteractiveInput interactiveInput = new InteractiveInput();
+            interactiveInput.update("questioner", reply);   // "questioner" must match the component id used at registration
+
+            // Resume execution in the same session
+            output = workflow.invoke(interactiveInput, session, null);
+        }
+
+        // 8. Check final state
+        if (WorkflowExecutionState.COMPLETED.equals(output.getState())) {
+            System.out.println(">>> Workflow completed (state=COMPLETED)");
+            System.out.println(">>> Result: " + output.getResult());
+        } else if (WorkflowExecutionState.ERROR.equals(output.getState())) {
+            System.out.println(">>> Workflow error (state=ERROR)");
+            System.out.println(">>> Result: " + output.getResult());
+        } else {
+            System.out.println(">>> Workflow state: " + output.getState());
+            System.out.println(">>> Result: " + output.getResult());
+        }
+    }
+
+    /**
+     * Model client configuration.
+     * In real projects, use SharedExampleApiConfigLoader to read from apiconfig.json.
+     * Here parameters are passed directly for a self-contained example.
+     */
+    private static ModelClientConfig createModelClientConfig() {
+        // Replace with your real values
+        return ModelClientConfig.builder()
+                .provider("your-provider")           // MODEL_PROVIDER, e.g. openai / azure / qwen
+                .apiKey("your-api-key")              // API_KEY
+                .apiBaseUrl("https://your-api-base") // API_BASE
+                .build();
+    }
+
+    /**
+     * Model request parameter configuration.
+     */
+    private static ModelRequestConfig createModelRequestConfig() {
+        ModelRequestConfig config = new ModelRequestConfig();
+        config.setModelName("your-model-name");     // MODEL_NAME
+        config.setTemperature(0.2);
+        config.setTopP(0.9);
+        return config;
+    }
+}

--- a/.claude/skills/workflow-guide/references/components_guide.md
+++ b/.claude/skills/workflow-guide/references/components_guide.md
@@ -1,0 +1,250 @@
+# Component Configuration Guide
+
+This file supplements the component section of SKILL.md, providing configuration details for each built-in component and an in-depth explanation of the 4 ability types. Read on demand when users ask "how to configure a certain component".
+
+## Component Ability Types (ComponentAbility)
+
+The four abilities are essentially four input/output patterns:
+
+| Ability | Input | Output | Corresponding Method | Suitable Scenario |
+| --- | --- | --- | --- | --- |
+| `INVOKE` | batch | batch | `invoke(...)` | Normal nodes: Start, Questioner, Tool |
+| `STREAM` | batch | stream | `stream(...)` | LLM chunk-by-chunk output, ProducerNode |
+| `COLLECT` | stream | batch | `collect(...)` | Aggregate upstream multi-frame, End receives stream then returns batch |
+| `TRANSFORM` | stream | stream | `transform(...)` | Per-frame rewriting, filtering, field supplementation |
+
+The criterion is simply whether the input and output are streams. There are no additional "semi-streaming" or "async batch" ability terms.
+
+### INVOKE
+The most common batch node: receives complete input, executes once, returns complete output.
+- `Start` passes through top-level input
+- `QuestionerComponent` reads input and returns fields or interrupts with a request
+- `ToolComponent` executes tool calls
+- Most custom nodes that only need to return results in one shot
+
+### STREAM
+Receives complete input, produces output frames incrementally.
+- Upstream sends batch in via `addConnection(...)`
+- Downstream consumes the stream via `addStreamConnection(...)`
+- LLM node continuously pushes tokens/chunks
+
+### COLLECT
+The opposite of STREAM: consumes a stream, produces a one-shot result.
+- Aggregates upstream multi-frame into a final value
+- Aggregates multiple stream chunks into a string, array, or statistics
+- End node receives stream then returns batch uniformly
+
+### TRANSFORM
+Consumes a stream, continues outputting a stream. Suitable for per-frame rewriting, filtering, field supplementation, or repackaging.
+
+### Edge Pairing Rules
+- Upstream INVOKE -> Downstream INVOKE: `addConnection`
+- Upstream STREAM/TRANSFORM -> Downstream TRANSFORM/COLLECT: `addStreamConnection`
+- Conditional branching: `addConditionalConnection` + router
+
+## Start Component
+
+Entry node, passes through input as-is.
+
+```java
+workflow.setStartComp(
+    "start",                              // Component id
+    new Start(),                           // Component instance
+    Map.of("query", "${query}"),           // inputsSchema: read from top-level input
+    null                                   // outputsSchema (optional)
+);
+```
+
+**Schema reference**:
+- `${query}` reads from workflow top-level input
+- Subsequent nodes read Start output using `${start.query}`
+
+## End Component
+
+Exit node, produces the final result. Two modes:
+
+### Batch Mode (default)
+```java
+workflow.setEndComp(
+    "end",
+    new End(Map.of("responseTemplate", "Transfer amount is {{amount}}")),
+    Map.of("amount", "${questioner.amount}"),  // inputsSchema
+    null
+);
+```
+
+### Streaming Mode
+```java
+workflow.setEndComp(
+    "end",
+    new End(Map.of("responseTemplate", "{{answer}}")),
+    null,                                        // inputsSchema (batch)
+    null,                                        // outputsSchema
+    Map.of("answer", "${llm.answer}"),           // streamInputsSchema (streaming)
+    null,
+    "streaming"                                  // responseMode
+);
+```
+
+**Key Points**:
+- Batch mode uses the 3rd parameter `inputsSchema`
+- Streaming mode uses the 5th parameter `streamInputsSchema`
+- `responseTemplate` uses `{{var}}` for rendering; variables must have their source declared in upstream schema
+
+## QuestionerComponent
+
+Used for scenarios where "fields may be missing and need runtime follow-up questions".
+
+```java
+QuestionerConfig config = new QuestionerConfig();
+config.setModelClientConfig(clientConfig);        // LLM client configuration
+config.setModelConfig(requestConfig);             // Request parameter configuration
+config.setQuestionContent("Please provide the transfer amount");  // Follow-up prompt text
+config.setExtractFieldsFromResponse(true);        // Extract fields from model response
+config.setFieldNames(List.of(                     // Fields to extract
+    FieldInfo.builder()
+        .fieldName("amount")
+        .description("Transfer amount")
+        .required(true)
+        .build()
+));
+config.setWithChatHistory(false);                  // Whether to include chat history
+config.setMaxResponse(10);                         // Maximum reply rounds
+```
+
+**Triggers `INPUT_REQUIRED`**: When fields are missing, the workflow returns `INPUT_REQUIRED`; the caller constructs `InteractiveInput` to resume.
+
+**When resuming**:
+```java
+InteractiveInput reply = new InteractiveInput();
+reply.update("questioner", "2000 yuan");  // Component id must be "questioner"
+```
+
+## LLMComponent
+
+Calls the LLM, supports streaming output.
+
+```java
+LLMCompConfig config = new LLMCompConfig();
+config.setModelClientConfig(clientConfig);
+config.setModelConfig(requestConfig);
+
+// Template content (supports multi-turn)
+config.setTemplateContent(List.of(
+    Map.of("role", "system", "content", "You are a concise assistant."),
+    Map.of("role", "user", "content", "{{query}}")  // {{}} renders variables
+));
+
+// Response format
+config.setResponseFormat(Map.of("type", "text"));
+
+// Output schema: declare which fields the LLM outputs
+config.setOutputConfig(Map.of(
+    "answer", Map.of(
+        "type", "string",
+        "description", "Model answer",
+        "required", true
+    )
+));
+```
+
+**Streaming output**: LLMComponent has `STREAM` ability by default; use `addStreamConnection(...)` to connect incremental output to downstream.
+
+## BranchComponent / Conditional Routing
+
+There are two ways to implement conditional branching:
+
+### Method 1: BranchComponent
+A dedicated branching component where internal logic determines routing.
+
+### Method 2: addConditionalConnection + router
+Lighter weight, define routing directly on the edge:
+
+```java
+// BranchRouter
+workflow.addConditionalConnection("src_id", new BranchRouter(...));
+
+// Or Function routing
+workflow.addConditionalConnection("src_id", (Function<Object, Object>) input -> {
+    Map<String, String> map = (Map<String, String>) input;
+    return switch (map.get("intent")) {
+        case "transfer" -> "transfer_node";
+        case "query" -> "query_node";
+        default -> "default_node";
+    };
+});
+```
+
+**Router return value** must be a registered component id, otherwise routing fails.
+
+## SubWorkflowComponentImpl
+
+Wraps another Workflow as a node in the current graph:
+
+```java
+// Build sub-workflow
+Workflow subWorkflow = new Workflow(subCard);
+subWorkflow.setStartComp("sub_start", new Start(), Map.of("input", "${input}"), null);
+// ... sub-workflow nodes and edges
+
+// Wrap as parent workflow node
+workflow.addWorkflowComp("sub", new SubWorkflowComponentImpl(subWorkflow),
+        Map.of("input", "${start.input}"), null);
+workflow.addConnection("start", "sub");
+workflow.addConnection("sub", "end");
+```
+
+**Benefits**:
+- Layered organization of complex processes
+- Reusable common sub-processes
+- Clearer visual structure
+
+## Custom Components
+
+When built-in components are insufficient, extend based on `WorkflowComponent` or `ComponentComposable`:
+
+```java
+public class MyComponent extends WorkflowComponent {
+    public MyComponent() {
+        super(ComponentAbility.INVOKE);  // Declare ability type
+    }
+
+    @Override
+    public Object invoke(Map<String, Object> inputs, WorkflowSessionApi session) {
+        // batch in, batch out
+        String query = (String) inputs.get("query");
+        return Map.of("result", process(query));
+    }
+}
+```
+
+**Implementation method depends on ability type**:
+- `INVOKE` -> implement `invoke(...)`
+- `STREAM` -> implement `stream(...)`, return `Iterator<WorkflowChunk>`
+- `COLLECT` -> implement `collect(...)`, consume stream, return batch
+- `TRANSFORM` -> implement `transform(...)`, consume stream, return stream
+
+## Schema Reference Syntax Summary
+
+| Syntax | Meaning | Used In |
+| --- | --- | --- |
+| `${query}` | Read from workflow top-level input | Any node's inputsSchema |
+| `${start.query}` | Read from Start output | Subsequent nodes' inputsSchema |
+| `${questioner.amount}` | Read from questioner output | Subsequent nodes' inputsSchema |
+| `{{query}}` | Render variable | LLMComponent's templateContent / End's responseTemplate |
+
+**Key**: `inputsSchema` only describes "where to get values" and **does not form execution order**; execution order is determined by `addConnection(...)`.
+
+## Three Steps of Orchestration
+
+Writing a Java workflow requires at least three things:
+
+1. **Register nodes**: `setStartComp(...)` / `addWorkflowComp(...)` / `setEndComp(...)`
+2. **Configure schema**: Let nodes know where to get values and what fields to expose downstream
+3. **Establish edge relationships**: Let the executor know what path to schedule nodes along
+
+Many beginners confuse step 2 with step 3. How to distinguish:
+- `Map.of("amount", "${questioner.amount}")` resolves "which value to read"
+- `addConnection("questioner", "end")` resolves "when to execute to end"
+
+**Both are required**.

--- a/.claude/skills/workflow-guide/references/key_concepts.md
+++ b/.claude/skills/workflow-guide/references/key_concepts.md
@@ -1,0 +1,179 @@
+# Workflow Key Concepts In-Depth
+
+This file supplements the "Key Concepts Quick Reference" in SKILL.md, providing deeper explanations for each concept. Read on demand when users ask "what does a certain concept mean".
+
+## Capability Layering Mental Model
+
+Understand the Java workflow across four layers:
+
+1. **Graph Definition Layer**: `Workflow` / `WorkflowCard` -- what this graph is
+2. **Component Orchestration Layer**: `Start` / `End` / business nodes / edges -- what nodes are in the graph and how they connect
+3. **Execution and Session Layer**: `WorkflowSessions` / `WorkflowOutput` / `WorkflowExecutionState` / `WorkflowChunk` -- how this execution runs and how state is carried
+4. **Application Integration Layer**: `WorkflowAgent` / `Runner` -- how to embed into a more complete application
+
+For building a single workflow, the first three layers are sufficient; the fourth layer is only needed for multi-workflow entry points.
+
+## Workflow
+
+`Workflow` is the central object, simultaneously responsible for three things:
+
+1. **Graph composition**: Register nodes, declare input/output schemas, connect edges
+2. **Execution**: `invoke(...)` batch / `stream(...)` incremental
+3. **Compatibility wrapping**: Multiple overloads for different parameter orders, different schema writing styles, and legacy integration
+
+Understand it as "an executable graph". It is not a workflow list, not an intent router -- those application-layer responsibilities belong to `WorkflowAgent`.
+
+## WorkflowCard
+
+The identity card of a workflow, most commonly containing: `id` / `name` / `version` / `description` / `inputParams`.
+
+It is not just "for human reading":
+- `Workflow` itself holds this card
+- `WorkflowAgent.addWorkflows(...)` reads the `WorkflowCard` description information during registration
+- `inputParams` is the input schema this workflow exposes externally
+
+`WorkflowCard` represents "who this workflow is and what input it accepts", not runtime dynamic state.
+
+## Nodes / Components
+
+Each node in the workflow graph is a "component", divided into three categories:
+
+### Start/End Nodes
+- `Start`: Entry node, passes through input as-is
+- `End`: Exit node, produces the final result; can return batch results or participate in `stream` / `transform` / `collect`
+
+### Business Nodes
+- `QuestionerComponent`: Asks follow-up questions for missing fields, triggers `INPUT_REQUIRED`
+- `LLMComponent`: Calls the LLM, supports streaming output
+- `BranchComponent`: Conditional branching
+- `IntentDetectionComponent`: Intent recognition
+- `SubWorkflowComponentImpl`: Sub-workflow
+
+### Custom Nodes
+Extend based on `WorkflowComponent` or `ComponentComposable`.
+
+## Edges: Normal Edge / Conditional Edge / Streaming Edge
+
+Registering components only places nodes; to make the graph run, edges must define execution relationships.
+
+### Normal Edge `addConnection(...)`
+Sequential dependency: the previous one finishes before the next one executes. Suitable for: linear processes, convergence after parallel branches, batch input/output passing.
+
+### Conditional Edge `addConditionalConnection(...)`
+The next node is decided at runtime. Supports two types of routing input:
+- `BranchRouter`
+- `Function<Object, Object>` routing function
+
+Suitable for: conditional branching, dynamic routing, loops or back-jumps.
+
+### Streaming Edge `addStreamConnection(...)`
+Passes incremental output between nodes that support streaming capability. Typical pairing:
+- Upstream `STREAM` or `TRANSFORM`
+- Downstream `TRANSFORM` or `COLLECT`
+
+Most common scenario: `LLMComponent` produces chunks -> `End` outputs with `responseMode = "streaming"`.
+
+**Note**: Conditional routing does not correspond to an additional `ConnectionType` enum value; it is expressed through `addConditionalConnection(...)` + router.
+
+## WorkflowSessions and Session
+
+`WorkflowSessions` is the workflow package-level session creation facade, most commonly used entry points:
+- `WorkflowSessions.createWorkflowSession()`
+- `WorkflowSessions.createWorkflowSession(String sessionId)`
+
+Returns `WorkflowSessionApi`, which handles:
+- Saving execution state for this run
+- Sharing intermediate results between nodes
+- Handling interactive input resumption
+- Managing streaming output, trace, and other runtime capabilities
+
+**Key**: When a workflow execution is interrupted and needs to continue the same flow, the same session must be reused.
+
+## WorkflowOutput
+
+The return container from `invoke(...)`, containing two fields:
+- `result`: Execution result
+- `state`: `WorkflowExecutionState`
+
+How to read:
+```java
+WorkflowOutput output = workflow.invoke(inputs, session, null);
+Object result = output.getResult();
+WorkflowExecutionState state = output.getState();
+```
+
+Typical return forms:
+- `state == COMPLETED`: `result` is the business output organized by `End`
+- `state == INPUT_REQUIRED`: `result` is a collection of interactive output blocks; the caller needs to submit `InteractiveInput` to continue
+- `state == ERROR`: Execution failed
+
+## WorkflowExecutionState
+
+| State | Meaning | How Caller Should Handle |
+| --- | --- | --- |
+| `COMPLETED` | Normal completion | Read `WorkflowOutput.getResult()` |
+| `INPUT_REQUIRED` | More user input needed | Read interaction prompt, construct `InteractiveInput`, then call `invoke` again |
+| `ERROR` | Execution failed | Log exception or propagate upward |
+
+`INPUT_REQUIRED` is not a failure; it is an intermediate state meaning "waiting for additional input".
+
+## Streaming Output: WorkflowChunk / OutputSchema / StreamMode
+
+Java workflow streaming execution uses a **synchronous `Iterator<WorkflowChunk>`**.
+
+### WorkflowChunk
+Top-level alias interface for streaming chunks. The concrete type callers most commonly receive is `OutputSchema`.
+
+### OutputSchema
+Standard output chunk, containing:
+- `type`
+- `index`
+- `payload`
+
+Callers can iterate the iterator and refresh the UI or logs chunk by chunk.
+
+### StreamMode
+`workflow.stream(...)` specifies which streams to subscribe to via `List<StreamMode>`:
+- `StreamMode.OUTPUT` (most commonly used for beginners)
+- `StreamMode.TRACE`
+- `StreamMode.CUSTOM`
+
+**Note**: `StreamMode` indicates "which type of stream to subscribe to"; `WorkflowChunkType` is the top-level naming for chunk categories. The two are related but not at the same level.
+
+## InteractiveInput
+
+When `QuestionerComponent` requires additional information, the workflow returns `INPUT_REQUIRED`. The caller:
+
+1. Reads the current interaction prompt
+2. Constructs `InteractiveInput`
+3. Calls `workflow.invoke(...)` again using the **same session**
+
+```java
+InteractiveInput reply = new InteractiveInput();
+reply.update("questioner", "2000 yuan");  // "questioner" = component id
+WorkflowOutput resumed = workflow.invoke(reply, session, null);
+```
+
+`"questioner"` must match the component id actually registered in the workflow.
+
+## SubWorkflowComponentImpl
+
+Wraps another `Workflow` as a node in the current graph:
+- Layered organization of complex processes
+- Reusable common sub-processes
+- Clearer visualization and structure
+
+## Connecting Concepts: A Typical Execution
+
+1. Use `WorkflowCard` to describe the workflow identity and input
+2. Use `Workflow` to register `Start`, business nodes, and `End`
+3. Use normal edges, conditional edges, or streaming edges to connect nodes into a graph
+4. Use `WorkflowSessions` to create the execution session
+5. Call `invoke(...)` to get `WorkflowOutput`, or `stream(...)` to get `Iterator<WorkflowChunk>`
+6. If `INPUT_REQUIRED`, use `InteractiveInput` to resume execution in the same session
+
+## Terminology Boundary Reminders
+
+- `Workflow` != `WorkflowAgent`: the former is a single graph, the latter is the application-layer entry point
+- `WorkflowCard` != session: the former is static description, the latter is runtime state
+- `stream(...)` chunk output != `invoke(...)` final result: the former is incremental process, the latter is the return package after execution concludes

--- a/.claude/skills/workflow-guide/references/workflow_cases.md
+++ b/.claude/skills/workflow-guide/references/workflow_cases.md
@@ -1,0 +1,377 @@
+# Workflow Real-World Cases
+
+This file provides 4 end-to-end cases, each containing "scenario -> workflow graph -> key code -> execution flow -> notes". Read on demand when users ask "give me a workflow case" or "how to build a certain type of workflow".
+
+## Case 1: Financial Assistant Multi-Workflow (WorkflowAgent + Intent Routing)
+
+**Corresponds to**: `examples/workflow_agent/WorkflowAgentExampleSupport.java`
+
+### Scenario
+
+A financial assistant hosts 3 workflows: transfer / investment / balance inquiry. When the user says "I want to transfer", the transfer flow is entered; when they say "check balance", the balance flow is entered. Each workflow has a follow-up question step (asking for amount/product/account when missing).
+
+### Workflow Graph
+
+```
+User Input
+   |
+   v
+WorkflowAgent (intent recognition)
+   |-- "transfer" --> transfer_flow_multi: Start -> Questioner(amount) -> End
+   |-- "investment" --> invest_flow_multi:    Start -> Questioner(product) -> End
+   |-- "check balance" -> balance_flow:        Start -> Questioner(account) -> End
+   +-- other --> defaultResponse
+```
+
+### Key Code
+
+**Create agent + register 3 workflows**:
+
+```java
+WorkflowAgentConfig config = WorkflowAgentConfig.builder()
+        .id("workflow_agent_java_example")
+        .description("Java multi-workflow financial assistant example")
+        .model(modelConfig)
+        .promptTemplate(List.of(Map.of("role", "system", "content",
+            "You are a financial business assistant. When users request transfers, "
+            + "investments, or balance inquiries, you must select the most appropriate "
+            + "workflow to handle it. If information is incomplete, use the questioning "
+            + "node within the workflow to collect missing fields. If the user's request "
+            + "does not belong to these three business categories, return the default reply directly.")))
+        .defaultResponse(DefaultResponse.builder()
+            .text("I currently only support three financial processes: transfers, investments, and balance inquiries. Please clearly state your request.")
+            .build())
+        .build();
+
+WorkflowAgent agent = new WorkflowAgent(config);
+agent.addWorkflows(List.of(
+        buildFinancialWorkflow("transfer_flow_multi", "Transfer Service",
+                "Handle user transfer, remittance, payment requests...", "amount",
+                "Transfer amount", "Transfer service completed, amount is {{amount}}."),
+        buildFinancialWorkflow("invest_flow_multi", "Investment Service",
+                "Handle investment requests...", "product",
+                "Investment product name", "Investment service completed, product is {{product}}."),
+        buildFinancialWorkflow("balance_flow", "Balance Inquiry",
+                "Handle account balance inquiry requests...", "account",
+                "Account number", "Balance inquiry completed, account is {{account}}.")
+));
+```
+
+**Building each workflow** (using a helper method for reuse):
+
+```java
+private static Workflow buildFinancialWorkflow(String id, String name,
+        String desc, String fieldName, String fieldDesc, String template) {
+    WorkflowCard card = WorkflowCard.builder()
+            .id(id).name(name).version("1.0").description(desc)
+            .inputParams(defaultInputSchema()).build();
+
+    QuestionerConfig qConfig = new QuestionerConfig();
+    qConfig.setModelClientConfig(clientConfig);
+    qConfig.setModelConfig(requestConfig);
+    qConfig.setQuestionContent("Please provide " + fieldDesc);
+    qConfig.setExtractFieldsFromResponse(true);
+    qConfig.setFieldNames(List.of(FieldInfo.builder()
+            .fieldName(fieldName).description(fieldDesc).required(true).build()));
+    qConfig.setWithChatHistory(false);
+    qConfig.setMaxResponse(10);
+
+    Workflow wf = new Workflow(card);
+    wf.setStartComp("start", new Start(), Map.of("query", "${query}"), null);
+    wf.addWorkflowComp("questioner", new QuestionerComponent(qConfig),
+            Map.of("query", "${start.query}"), null);
+    wf.setEndComp("end", new End(Map.of("responseTemplate", template)),
+            Map.of(fieldName, "${questioner." + fieldName + "}"), null);
+    wf.addConnection("start", "questioner");
+    wf.addConnection("questioner", "end");
+    return wf;
+}
+```
+
+### Execution Flow
+
+1. User inputs "I want to transfer 2000 yuan"
+2. `WorkflowEventHandler.intentDetection(...)` performs intent recognition -> matches `transfer_flow_multi`
+3. Executes transfer workflow: Start -> Questioner (amount already in input, no follow-up needed) -> End
+4. Returns `COMPLETED`, output "Transfer service completed, amount is 2000 yuan"
+
+If the user only says "I want to transfer" (no amount):
+1. Intent recognition matches transfer workflow
+2. Start -> Questioner (amount missing) -> returns `INPUT_REQUIRED`
+3. User answers "2000 yuan" -> `InteractiveInput.update("questioner", "2000 yuan")`
+4. Resume execution in same session -> Questioner extracts amount -> End -> `COMPLETED`
+
+### Notes
+
+- **Write clear workflow descriptions**: Intent recognition relies on description matching; vague descriptions will lead to defaultResponse
+- **defaultResponse must be set**: When intent is not matched, return a default reply rather than forcing a wrong workflow selection
+- **Reuse the same session when resuming**: Switching sessions will lose follow-up context
+- **`reply.update` component id must be `"questioner"`**: Must match the id used at registration
+
+---
+
+## Case 2: Streaming Q&A Assistant (LLMComponent + End streaming)
+
+**Corresponds to**: Simplified version of `examples/interact/WeatherAssistantInteractExampleSupport.java`
+
+### Scenario
+
+User asks a question, LLM streams the answer, frontend displays output incrementally.
+
+### Workflow Graph
+
+```
+Start --batch--> LLMComponent --stream--> End(streaming)
+                    |                          |
+                    | LLM produces chunks      | End forwards chunks
+                    v                          v
+               Iterator<WorkflowChunk> <- caller consumes
+```
+
+### Key Code
+
+```java
+LLMCompConfig llmConfig = new LLMCompConfig();
+llmConfig.setModelClientConfig(clientConfig);
+llmConfig.setModelConfig(requestConfig);
+llmConfig.setTemplateContent(List.of(
+        Map.of("role", "system", "content", "You are a concise assistant."),
+        Map.of("role", "user", "content", "{{query}}")  // {{}} renders
+));
+llmConfig.setResponseFormat(Map.of("type", "text"));
+llmConfig.setOutputConfig(Map.of(
+        "answer", Map.of("type", "string", "description", "Model answer", "required", true)
+));
+
+Workflow workflow = new Workflow();
+workflow.setStartComp("start", new Start(), Map.of("query", "${query}"), null);
+workflow.addWorkflowComp("llm", new LLMComponent(llmConfig),
+        Map.of("query", "${start.query}"), null);
+
+// End uses streaming mode; the 5th parameter is streamInputsSchema
+workflow.setEndComp("end",
+        new End(Map.of("responseTemplate", "{{answer}}")),
+        null,                                    // inputsSchema (batch, not used here)
+        null,                                    // outputsSchema
+        Map.of("answer", "${llm.answer}"),       // streamInputsSchema (streaming)
+        null,
+        "streaming");                            // responseMode
+
+// Connect edges: start->llm uses normal edge, llm->end uses streaming edge
+workflow.addConnection("start", "llm");
+workflow.addStreamConnection("llm", "end");
+
+// Execute
+Iterator<WorkflowChunk> chunks = workflow.stream(
+        Map.of("query", "Introduce Java workflows"),
+        WorkflowSessions.createWorkflowSession(),
+        null,
+        List.of(StreamMode.OUTPUT));
+
+while (chunks.hasNext()) {
+    WorkflowChunk chunk = chunks.next();
+    if (chunk instanceof OutputSchema output) {
+        System.out.print(output.getPayload());  // Print incrementally
+    }
+}
+```
+
+### Execution Flow
+
+1. `stream(...)` returns a synchronous Iterator
+2. LLMComponent produces tokens/chunks incrementally
+3. Streaming edge passes chunks to End
+4. End outputs chunks incrementally in streaming mode
+5. Caller iterates the Iterator, consuming chunks
+
+### Notes
+
+- **End streaming mode must use `streamInputsSchema`** (5th parameter), not `inputsSchema` (3rd parameter)
+- **`addStreamConnection` must not be omitted**: Only `addConnection` will not make streaming data flow
+- **`StreamMode.OUTPUT` must be passed**: Not passing or passing wrong will result in no data
+- **Iterator is synchronous**: Not an async stream; `hasNext()` blocks waiting for the next chunk
+
+---
+
+## Case 3: Form Filling with Follow-up Questions (Multi-field QuestionerComponent)
+
+### Scenario
+
+User wants to apply for a credit card, needs to fill in 4 fields: name, ID number, phone, and email. The user may only provide some fields; QuestionerComponent asks follow-up questions for missing fields.
+
+### Workflow Graph
+
+```
+Start --> Questioner(multi-field) --> End
+              |
+              | Fields missing -> INPUT_REQUIRED
+              | All fields present -> continue execution
+              v
+         User reply -> resume in same session
+```
+
+### Key Code
+
+```java
+QuestionerConfig config = new QuestionerConfig();
+config.setModelClientConfig(clientConfig);
+config.setModelConfig(requestConfig);
+config.setQuestionContent("Please provide the following information");
+config.setExtractFieldsFromResponse(true);
+config.setFieldNames(List.of(
+    FieldInfo.builder().fieldName("name")
+        .description("Name").required(true).build(),
+    FieldInfo.builder().fieldName("idCard")
+        .description("ID number").required(true).build(),
+    FieldInfo.builder().fieldName("phone")
+        .description("Phone number").required(true).build(),
+    FieldInfo.builder().fieldName("email")
+        .description("Email").required(false).build()  // Optional
+));
+config.setWithChatHistory(true);   // Multi-turn follow-up requires chat history
+config.setMaxResponse(10);         // Maximum 10 follow-up rounds
+
+Workflow workflow = new Workflow(card);
+workflow.setStartComp("start", new Start(), Map.of("query", "${query}"), null);
+workflow.addWorkflowComp("questioner", new QuestionerComponent(config),
+        Map.of("query", "${start.query}"), null);
+workflow.setEndComp("end",
+        new End(Map.of("responseTemplate",
+            "Credit card application submitted: {{name}} / {{idCard}} / {{phone}} / {{email}}")),
+        Map.of(
+            "name", "${questioner.name}",
+            "idCard", "${questioner.idCard}",
+            "phone", "${questioner.phone}",
+            "email", "${questioner.email}"
+        ),
+        null);
+workflow.addConnection("start", "questioner");
+workflow.addConnection("questioner", "end");
+```
+
+### Execution Flow
+
+1. User: "I want to apply for a credit card, my name is Zhang San"
+2. Start -> Questioner: extracts name=Zhang San, but idCard/phone/email are missing
+3. Returns `INPUT_REQUIRED`, prompts user for ID number
+4. User: "110101199001011234"
+5. Resume in same session -> Questioner: extracts idCard, phone/email still missing
+6. Returns `INPUT_REQUIRED`, prompts for phone number
+7. User: "13800138000"
+8. Resume -> extracts phone, email is optional -> all required fields present
+9. -> End -> `COMPLETED`, output "Credit card application submitted: Zhang San / 110101... / 138... / null"
+
+### Notes
+
+- **`setWithChatHistory(true)`**: Multi-turn follow-up must include chat history, otherwise Questioner does not know what was previously asked
+- **`setMaxResponse(10)`**: Limits maximum follow-up rounds to prevent infinite loops
+- **Optional fields (`required=false`)**: Missing optional fields do not trigger follow-up, but `{{email}}` in the End template will render as null
+- **Each `InteractiveInput.update` answers one question at a time**: Even for multi-field follow-up, one is answered at a time; Questioner decides what to ask next
+
+---
+
+## Case 4: Conditional Branching Workflow (BranchComponent + Multi-branch Routing)
+
+### Scenario
+
+Customer service bot: user says "refund" goes to refund flow, says "inquiry" goes to inquiry flow, says "complaint" goes to complaint flow.
+
+### Workflow Graph
+
+```
+                Start
+                  |
+                  v
+          IntentDetection
+                  |
+            (conditional edge routing)
+              +---+---+
+              v   v   v
+          Refund  Inquiry  Complaint
+          Node    Node     Node
+              +---+---+
+                  v
+                 End
+```
+
+### Key Code
+
+```java
+Workflow workflow = new Workflow(card);
+workflow.setStartComp("start", new Start(), Map.of("query", "${query}"), null);
+
+// Intent detection node
+IntentDetectionConfig intentConfig = new IntentDetectionConfig();
+intentConfig.setModelClientConfig(clientConfig);
+intentConfig.setModelConfig(requestConfig);
+intentConfig.setIntents(List.of(
+    IntentInfo.builder().name("refund").description("Refund, return, money back").build(),
+    IntentInfo.builder().name("consult").description("Inquiry, ask, learn about").build(),
+    IntentInfo.builder().name("complain").description("Complaint, report, dissatisfaction").build()
+));
+workflow.addWorkflowComp("intent", new IntentDetectionComponent(intentConfig),
+        Map.of("query", "${start.query}"), null);
+
+// Three business nodes
+workflow.addWorkflowComp("refund", new RefundComponent(),
+        Map.of("query", "${start.query}"), null);
+workflow.addWorkflowComp("consult", new ConsultComponent(),
+        Map.of("query", "${start.query}"), null);
+workflow.addWorkflowComp("complain", new ComplainComponent(),
+        Map.of("query", "${start.query}"), null);
+
+// End
+workflow.setEndComp("end", new End(Map.of("responseTemplate", "{{result}}")),
+        Map.of("result", "${refund.result}",  // All three nodes map to result
+                      "result", "${consult.result}",
+                      "result", "${complain.result}"),
+        null);
+
+// Connect edges: start -> intent uses normal edge
+workflow.addConnection("start", "intent");
+
+// intent -> three branches use conditional edge (Function routing)
+workflow.addConditionalConnection("intent", (Function<Object, Object>) input -> {
+    String intentName = ((Map<String, String>) input).get("intentName");
+    return switch (intentName) {
+        case "refund" -> "refund";
+        case "consult" -> "consult";
+        case "complain" -> "complain";
+        default -> "consult";  // Fallback
+    };
+});
+
+// Three branches -> end use normal edges
+workflow.addConnection("refund", "end");
+workflow.addConnection("consult", "end");
+workflow.addConnection("complain", "end");
+```
+
+### Execution Flow
+
+1. User: "I want a refund"
+2. Start -> IntentDetection: recognizes intent=refund
+3. Conditional edge routing: intent=refund -> goes to refund node
+4. RefundComponent executes refund logic
+5. -> End -> `COMPLETED`
+
+### Notes
+
+- **Router return value must be a registered component id**: Returning `"refund"` requires `addWorkflowComp("refund", ...)`
+- **Fallback branch must exist**: Intent recognition may not match; default should go to a safe branch
+- **Multiple branches converge to End**: End's inputsSchema must map all three nodes' result to the `result` field
+- **Conditional edge does not correspond to `ConnectionType`**: It is expressed via `addConditionalConnection` + router, not a separate edge type
+
+## Common Flow Across Cases
+
+Regardless of the workflow type, the building process is largely the same:
+
+1. **Define card**: `WorkflowCard` describes identity and input schema
+2. **Register nodes**: `setStartComp` / `addWorkflowComp` / `setEndComp`
+3. **Configure schema**: Each node uses `${...}` to declare where to get values
+4. **Connect edges**: `addConnection` (normal) / `addStreamConnection` (streaming) / `addConditionalConnection` (conditional)
+5. **Create session**: `WorkflowSessions.createWorkflowSession(...)`
+6. **Execute**: `invoke(...)` for batch or `stream(...)` for streaming
+7. **Handle state**: `COMPLETED` read result; `INPUT_REQUIRED` reply and resume in same session; `ERROR` handle exception
+
+After each `invoke` or `stream`, always check `WorkflowExecutionState` to determine the next action.

--- a/.claude/templates/README.md
+++ b/.claude/templates/README.md
@@ -1,0 +1,31 @@
+# Code Templates
+
+Scaffolding for new code in `agent-core-java`. Each template reflects
+actual patterns observed in the codebase — Lombok usage on Cards, plain
+POJO for services/tools, JUnit 5 + AssertJ + programmatic Mockito for
+tests, `ErrorHelper` + `StatusCode` for errors.
+
+## Usage
+
+When creating a new class, start from the matching template and adapt.
+Do not copy blindly — read nearby code in the target package first.
+
+## Files
+
+| Template | When to use |
+|---|---|
+| `card.java.tmpl` | New Card class extending `BaseCard` |
+| `service.java.tmpl` | Service/business class with logger, config, error handling |
+| `tool.java.tmpl` | Harness tool returning `ToolOutput` |
+| `test.java.tmpl` | JUnit 5 unit test with AssertJ + Mockito |
+| `exception.md.tmpl` | Adding a new `StatusCode` entry |
+
+## Conventions (apply to all templates)
+
+- Copyright header: `/* Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved. */`
+- Javadoc: method name as summary, `@param name name`, `@return the result`
+- Logger: `Loggers.XXX.error(...)` — never `System.out`, never direct `Logger`
+- ObjectMapper: `private static final ObjectMapper MAPPER = new ObjectMapper();`
+- Concurrency: `ConcurrentHashMap` for shared mutable maps
+- Errors: `throw ErrorHelper.buildError(StatusCode.X, "key", "value")`
+- Lombok: only on Card subclasses; services/tools are vanilla Java

--- a/.claude/templates/card.java.tmpl
+++ b/.claude/templates/card.java.tmpl
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+package com.openjiuwen.core.singleagent.schema;
+
+// =================================================================
+// TEMPLATE NOTES:
+//   1. Replace {{CardName}} with your Card class name.
+//   2. Replace field names (inputParams, outputParams) with actual metadata fields.
+//   3. Adjust the toolInfo() return type and ToolInfo.builder() call to match your needs.
+// =================================================================
+
+import com.openjiuwen.core.common.schema.BaseCard;
+import com.openjiuwen.core.foundation.tool.ToolInfo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Description of what this Card represents.
+ *
+ * <p>Used by [subsystem] to [purpose].
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class {{CardName}} extends BaseCard {
+
+    /** Example field — replace with actual metadata fields. */
+    private Object inputParams;
+    private Object outputParams;
+
+    @Override
+    public Object toolInfo() {
+        return ToolInfo.builder()
+                .name(getName())
+                .description(getDescription())
+                .parameters(getInputParamsAsMap())
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends BaseCard.Builder {
+        private Object inputParams;
+        private Object outputParams;
+
+        @Override
+        public Builder id(String id) {
+            super.id(id);
+            return this;
+        }
+
+        @Override
+        public Builder name(String name) {
+            super.name(name);
+            return this;
+        }
+
+        @Override
+        public Builder description(String description) {
+            super.description(description);
+            return this;
+        }
+
+        public Builder inputParams(Object inputParams) {
+            this.inputParams = inputParams;
+            return this;
+        }
+
+        public Builder outputParams(Object outputParams) {
+            this.outputParams = outputParams;
+            return this;
+        }
+
+        @Override
+        public {{CardName}} build() {
+            {{CardName}} card = new {{CardName}}();
+            card.setId(id);
+            card.setName(name);
+            card.setDescription(description);
+            card.setInputParams(inputParams);
+            card.setOutputParams(outputParams);
+            return card;
+        }
+    }
+}

--- a/.claude/templates/exception.md.tmpl
+++ b/.claude/templates/exception.md.tmpl
@@ -1,0 +1,57 @@
+# Adding a New StatusCode Entry
+
+## Step 1: Add to `StatusCode` enum
+
+File: `src/main/java/com/openjiuwen/core/common/exception/StatusCode.java`
+
+Find the numeric range section that matches your error category:
+
+| Range | Category | Example |
+|---|---|---|
+| 100xxx | Workflow | `WORKFLOW_EXECUTION_ERROR(100102, ...)` |
+| 12xxxx | Agent | `AGENT_CONTROLLER_RUNTIME_ERROR(120003, ...)` |
+| 15xxxx | Runner / Graph | — |
+| 18xxxx | Tool / Interface | `TOOL_EXECUTION_ERROR(182012, ...)` |
+| 19xxxx | Common / Security | `COMMON_JSON_INPUT_PROCESS_ERROR(188002, ...)` |
+
+Add the entry:
+
+```java
+EXAMPLE_NEW_ERROR(182013, "example new error, reason={reason}, context={context}"),
+```
+
+## Step 2: Verify no duplicate code
+
+Check that the integer code is unique in the enum. Duplicate codes cause
+`StatusMapping` ambiguity.
+
+## Step 3: Add compatibility test
+
+File: `src/test/java/com/openjiuwen/core/common/exception/StatusCodeTest.java`
+
+```java
+@Test
+@DisplayName("EXAMPLE_NEW_ERROR has correct code and message template")
+void testExampleNewError() {
+    StatusCode sc = StatusCode.EXAMPLE_NEW_ERROR;
+    assertThat(sc.getCode()).isEqualTo(182013);
+    assertThat(sc.getErrmsg()).contains("{reason}");
+    assertThat(sc.getErrmsg()).contains("{context}");
+}
+```
+
+## Step 4: Use it
+
+```java
+throw ErrorHelper.buildError(
+        StatusCode.EXAMPLE_NEW_ERROR,
+        "reason", "something failed",
+        "context", "additional info");
+```
+
+## Rules
+
+- Message template uses `{placeholder}` syntax (Python-compatible).
+- Do not raise bare `RuntimeException` — always go through `ErrorHelper`.
+- `ErrorHelper.buildError(...)` builds but does not throw; use `throw`.
+- `ErrorHelper.raiseError(...)` builds and throws in one call.

--- a/.claude/templates/service.java.tmpl
+++ b/.claude/templates/service.java.tmpl
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+package com.openjiuwen.core.singleagent;
+
+// =================================================================
+// TEMPLATE NOTES:
+//   1. Replace {{ClassName}} with your target class name.
+//   2. Replace {{ConfigClass}} and its import with the actual config class (or remove).
+//   3. Replace {{StatusCode}} with the matching StatusCode for your module.
+//   4. Replace {{Logger}} (Loggers.AGENT, Loggers.TOOL, etc.) to match your subsystem.
+//   5. Adjust extends clause (BaseAgent or other base) to match your hierarchy.
+// =================================================================
+
+import com.openjiuwen.core.common.exception.BaseError;
+import com.openjiuwen.core.common.exception.ErrorHelper;
+import com.openjiuwen.core.common.exception.StatusCode;
+import com.openjiuwen.core.common.logging.Loggers;
+import com.openjiuwen.core.singleagent.schema.AgentCard;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Description of the service responsibility.
+ *
+ * <p>Typical usage: [how this class is constructed and called].
+ */
+public class {{ClassName}} extends BaseAgent {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final {{ConfigClass}} config;
+    private final Map<String, Object> registry = new ConcurrentHashMap<>();
+
+    public {{ClassName}}(AgentCard card, {{ConfigClass}} config) {
+        super(card);
+        this.config = config != null ? config : new {{ConfigClass}}();
+    }
+
+    /**
+     * invoke.
+     *
+     * @param input input
+     * @param session session
+     * @return the result
+     */
+    public Object invoke(String input, Session session) {
+        if (input == null || input.isBlank()) {
+            throw ErrorHelper.buildError(
+                    StatusCode.{{StatusCode}},
+                    "error_msg", "input is required");
+        }
+        if (session == null) {
+            throw ErrorHelper.buildError(
+                    StatusCode.{{StatusCode}},
+                    "error_msg", "session is required");
+        }
+        try {
+            // Business logic here
+            return doInvoke(input, session);
+        } catch (BaseError e) {
+            throw e;
+        } catch (RuntimeException e) {
+            Loggers.{{Logger}}.error("{{ClassName}} invoke error: " + e.getMessage());
+            throw ErrorHelper.buildError(
+                    StatusCode.{{StatusCode}},
+                    "error_msg", e.getMessage());
+        }
+    }
+
+    private Object doInvoke(String input, Session session) {
+        // Implementation
+        return null;
+    }
+}

--- a/.claude/templates/test.java.tmpl
+++ b/.claude/templates/test.java.tmpl
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+package com.openjiuwen.core.singleagent;
+
+// =================================================================
+// TEMPLATE NOTES:
+//   1. Replace {{ClassName}} with your target class name.
+//   2. Replace {{TargetClass}} and {{TargetClass}} import with the actual class under test.
+//   3. Replace {{ConfigClass}} / {{ConfigClass}} import with the actual config class (or remove).
+//   4. Adjust Session / mock imports to match the real types in your package.
+//   5. Package-private class (no `public`).
+// =================================================================
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link {{TargetClass}}}.
+ */
+class {{ClassName}}Test {
+
+    private AgentCard card;
+    private {{ConfigClass}} config;
+
+    @BeforeEach
+    void setUp() {
+        card = AgentCard.builder()
+                .name("test-{{target-lower}}")
+                .description("Test {{target-lower}}")
+                .build();
+        config = new {{ConfigClass}}();
+    }
+
+    // ========== Construction ==========
+
+    @Nested
+    @DisplayName("Construction")
+    class Construction {
+
+        @Test
+        void testConstructionWithConfig() {
+            {{TargetClass}} service = new {{TargetClass}}(card, config);
+
+            assertThat(service.getCard().getName()).isEqualTo("test-{{target-lower}}");
+            assertThat(service.getConfig()).isSameAs(config);
+        }
+
+        @Test
+        void testConstructionNullConfigDefaults() {
+            {{TargetClass}} service = new {{TargetClass}}(card, null);
+
+            assertThat(service.getConfig()).isNotNull();
+        }
+    }
+
+    // ========== Invoke ==========
+
+    @Nested
+    @DisplayName("Invoke")
+    class Invoke {
+
+        @Test
+        void testInvokeNullInputThrows() {
+            {{TargetClass}} service = new {{TargetClass}}(card, config);
+            Session mockSession = mock(Session.class);
+
+            assertThatThrownBy(() -> service.invoke(null, mockSession))
+                    .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        void testInvokeSuccess() {
+            {{TargetClass}} service = new {{TargetClass}}(card, config);
+            Session mockSession = mock(Session.class);
+            when(mockSession.getSessionId()).thenReturn("sess-1");
+
+            Object result = service.invoke("hello", mockSession);
+
+            assertThat(result).isNotNull();
+            verify(mockSession).getSessionId();
+        }
+    }
+}

--- a/.claude/templates/tool.java.tmpl
+++ b/.claude/templates/tool.java.tmpl
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+package com.openjiuwen.harness.tools;
+
+// =================================================================
+// TEMPLATE NOTES:
+//   1. Replace {{ToolName}} with your tool class name.
+//   2. Replace {{Logger}} (Loggers.TOOL, Loggers.AGENT, etc.) to match your subsystem.
+//   3. Tools are plain POJOs — no framework annotations. Registration
+//      happens via ToolCard metadata and Runner.resourceMgr().
+// =================================================================
+
+import com.openjiuwen.core.common.logging.Loggers;
+
+import java.util.Map;
+
+/**
+ * Description of what this tool does and when it is invoked.
+ *
+ * <p>Tools are plain POJOs — no framework annotations. Registration
+ * happens via {@code ToolCard} metadata and {@code Runner.resourceMgr()}.
+ */
+public class {{ToolName}} {
+
+    private final String permissionMode;
+
+    public {{ToolName}}() {
+        this("auto");
+    }
+
+    public {{ToolName}}(String permissionMode) {
+        this.permissionMode = permissionMode != null ? permissionMode : "auto";
+    }
+
+    /**
+     * invoke.
+     *
+     * @param command command
+     * @param workdir workdir
+     * @return the result
+     */
+    public ToolOutput invoke(String command, String workdir) {
+        if (command == null || command.isBlank()) {
+            return ToolOutput.builder()
+                    .success(false)
+                    .error("command cannot be empty")
+                    .build();
+        }
+        try {
+            // Business logic here
+            return ToolOutput.builder()
+                    .success(true)
+                    .data(Map.of("status", "done"))
+                    .build();
+        } catch (Exception ex) {
+            Loggers.{{Logger}}.error("{{ToolName}} error: " + ex.getMessage());
+            return ToolOutput.builder()
+                    .success(false)
+                    .error(ex.getMessage())
+                    .build();
+        }
+    }
+
+    /** Structured result for callers that need typed access. */
+    public record InjectionCheck(boolean isBlocked, String reason) {
+    }
+}

--- a/.claude/test-scenarios/001-null-input.md
+++ b/.claude/test-scenarios/001-null-input.md
@@ -1,0 +1,53 @@
+---
+id: 001
+title: Public methods must throw BaseError on null input, not NullPointerException
+module: com.openjiuwen.core.singleagent
+priority: P0
+type: null
+tags: [npe, validation, error-helper, base-error]
+---
+
+## Description
+
+The project uses `ErrorHelper.buildError(StatusCode.X, ...)` to raise
+unified `BaseError` subclasses. All public methods that accept
+parameters must throw a `BaseError` with a `StatusCode` when receiving
+`null` input, rather than letting the JVM throw a bare
+`NullPointerException`. This ensures error codes are traceable and
+messages are formatted.
+
+Scope: all public methods with parameters under `com.openjiuwen.core`
+and `com.openjiuwen.harness`.
+
+Exception: internal private methods may use `Objects.requireNonNull`
+for assertions.
+
+## Input Conditions
+
+- `invoke(null, session)` — input is null
+- `invoke("hello", null)` — session is null
+- `invoke("", session)` — input is empty string
+- `invoke("   ", session)` — input is whitespace only
+
+## Expected Behavior
+
+- Throws a `BaseError` subclass (not `NullPointerException`)
+- Error code is the `StatusCode` matching the method's module
+  (e.g., `AGENT_CONTROLLER_RUNTIME_ERROR` for ControllerAgent,
+  `TOOL_EXECUTION_ERROR` for tools)
+- Message includes the parameter name and "is required" or "cannot be null/blank"
+
+## Test Location
+
+- `src/test/java/com/openjiuwen/core/singleagent/ControllerAgentTest.java`
+  - `testInvokeNullInputThrows` — input is null
+  - `testInvokeNullSessionThrows` — session is null
+  - `testInvokeBlankInputThrows` — input is empty/whitespace
+
+- `src/test/java/com/openjiuwen/harness/tools/BashToolTest.java`
+  - `testInvokeNullCommandReturnsFailedToolOutput` — Tool does not throw; returns `success=false`
+
+## Coverage
+
+- [x] ControllerAgent partially covered (`ControllerAgentTest.Invoke` nested class)
+- [ ] BashTool null path not covered

--- a/.claude/test-scenarios/002-concurrent-access.md
+++ b/.claude/test-scenarios/002-concurrent-access.md
@@ -1,0 +1,45 @@
+---
+id: 002
+title: Shared Map concurrent writes must use ConcurrentHashMap
+module: com.openjiuwen.core.singleagent
+priority: P0
+type: concurrency
+tags: [concurrency, hashmap, dead-loop, thread-safety]
+---
+
+## Description
+
+Classes holding `Map<String, ToolCard>` / `Map<String, AgentCard>`
+fields (e.g., `AbilityManager`) are read and written by multiple
+threads simultaneously (e.g., multiple Teammates registering tools in
+a Leader-Teammate team scenario). Using `HashMap` under concurrent
+put in Java 8+ can cause internal linked-list cycles, triggering
+infinite loops or data loss. `ConcurrentHashMap` is required (per
+`X.CON.05`).
+
+## Input Conditions
+
+- 10 threads calling `registerTool()` / `getTool()` concurrently
+- Each thread registers 100 distinct ToolCards
+- Runs for 5 seconds
+- Reader threads continuously iterate `getToolNames()`
+
+## Expected Behavior
+
+- No infinite loops (test completes within 10 seconds)
+- No `ConcurrentModificationException`
+- All registered tools are readable (count == 10 * 100)
+- No data loss
+
+## Test Location
+
+- `src/test/java/com/openjiuwen/core/singleagent/AbilityManagerTest.java`
+  - `testConcurrentRegisterAndGetNoException` — concurrent register + read
+  - `testConcurrentRegisterNoDataLoss` — registration count integrity
+
+- `src/test/java/com/openjiuwen/agentteams/agent/TeamAgentTest.java`
+  - `testMultipleTeammatesRegisterToolsConcurrently` — multi-Teammate concurrent registration
+
+## Coverage
+
+- [ ] not covered

--- a/.claude/test-scenarios/003-object-mapper-reuse.md
+++ b/.claude/test-scenarios/003-object-mapper-reuse.md
@@ -1,0 +1,39 @@
+---
+id: 003
+title: ObjectMapper must be class-level static final, never created inside methods
+module: com.openjiuwen.core.common
+priority: P0
+type: resource
+tags: [object-mapper, gc, performance, json]
+---
+
+## Description
+
+ObjectMapper is expensive to create (builds serializer/deserializer
+caches) but thread-safe and reusable. Any `new ObjectMapper()` inside
+a method body causes GC pressure under frequent invocation. It must be
+declared as a `private static final` class-level field, or obtained
+via `JsonUtils.getMapper()`.
+
+## Input Conditions
+
+- Check all occurrences of `new ObjectMapper()`
+- Distinguish class-level `static final` declarations (compliant) vs
+  in-method creation (non-compliant)
+
+## Expected Behavior
+
+- All ObjectMapper instances are `private static final` fields
+- No `new ObjectMapper()` inside method bodies
+- High-frequency methods like `BaseError.toJson()` are especially checked
+
+## Test Location
+
+- `src/test/java/com/openjiuwen/core/common/security/JsonUtilsTest.java`
+  - `testGetMapperReturnsSameInstance` — multiple calls return the same instance
+- `src/test/java/com/openjiuwen/core/common/exception/BaseErrorTest.java`
+  - `testToJsonDoesNotCreateNewObjectMapper` — multiple toJson calls do not create new instances
+
+## Coverage
+
+- [ ] not covered

--- a/.claude/test-scenarios/README.md
+++ b/.claude/test-scenarios/README.md
@@ -1,0 +1,85 @@
+# Test Scenarios — Error Path & Boundary Condition Library
+
+This directory archives error paths, boundary conditions, and
+concurrency scenarios that must be covered by tests. Claude automatically
+references these when writing or modifying tests to ensure no critical
+path is missed.
+
+## Directory structure
+
+```
+test-scenarios/
+  README.md                    ← this file
+  001-null-input.md            ← sample: null input
+  002-concurrent-access.md     ← sample: concurrent access
+  003-object-mapper-reuse.md   ← sample: resource reuse
+```
+
+## Scenario file format
+
+```markdown
+---
+id: 001
+title: Short title
+module: com.openjiuwen.xxx
+priority: P0 | P1 | P2
+type: null | boundary | concurrency | exception | resource
+tags: [npe, validation, ...]
+---
+
+## Description
+
+When this scenario is triggered and what the expected behavior is.
+
+## Input Conditions
+
+- Input values / state / concurrency conditions
+
+## Expected Behavior
+
+- Exception type to throw (`BaseError` + specific `StatusCode`)
+- Return value or state
+
+## Test Location
+
+- `src/test/java/...` — corresponding test method names
+
+## Coverage
+
+- [ ] not covered
+- [x] covered
+```
+
+## Scenario types
+
+| Type | Description | Example |
+|---|---|---|
+| `null` | null, empty string, empty collection | `invoke(null, session)` |
+| `boundary` | boundary values: 0, -1, MAX_VALUE, empty array | `tokenCount = Integer.MAX_VALUE` |
+| `concurrency` | concurrent read/write, race conditions | multiple threads writing to `ConcurrentHashMap` |
+| `exception` | exception propagation, error code mapping | `BaseError` passthrough vs `RuntimeException` wrapping |
+| `resource` | resource leak, IO close, timeout | `HttpClient` connection pool exhaustion |
+
+## Rules
+
+- Scenario IDs increment; never reuse deleted IDs.
+- `priority`: P0 = must cover, P1 = should cover, P2 = nice to have.
+- Test location must include the full path.
+- Coverage uses `[ ]` / `[x]; Claude updates it after writing tests.
+- When adding a new feature, Claude checks for uncovered matching
+  scenarios and reminds you to add tests.
+
+## Case vs Test-Scenario
+
+| When to use Case (`.claude/cases/`) | When to use Test-Scenario (this directory) |
+|---|---|
+| An incident or tricky bug that already happened | An error path or boundary condition to cover |
+| Has root-cause analysis and a fix | Only needs input and expected behavior |
+| Post-hoc archive, looking back | Upfront design, preventing future |
+| Template has `severity` / `date` | Template has `priority` / `type` |
+
+Rule of thumb: **Something broke → log a Case; something might break → log a Test-Scenario.**
+
+The two can cross-reference: a Case's `Related Files` links to the
+corresponding Test-Scenario, and the Test-Scenario's coverage status is
+updated when the Case's fix lands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+---
+description: Shared instructions for AI coding assistants in agent-core-java.
+---
+
+# AGENTS.md
+
+Shared instructions for AI coding assistants working in `agent-core-java`.
+Keep this file specific, factual, and cross-tool. Prefer nearby code and
+tests over assumptions.
+
+`pom.xml` is the canonical source of truth for build/tooling settings.
+
+## What This Repo Is
+
+- `com.openjiuwen.core/`: public SDK/runtime for agents, workflows, sessions,
+  memory, retrieval, security, and system operations.
+- `com.openjiuwen.harness/`: coding-agent framework built on core
+  primitives; includes prompts, rails, tools, subagents, task loop, and
+  workspace handling. Tool permission engine lives in `harness/security/`;
+  prompt/tool security rails live in `harness/rails/security/`.
+- `com.openjiuwen.agentteams/`: multi-agent team framework (Leader-Teammate
+  model). `LeaderTeammateAgentTeam` is the declarative entry point,
+  `TeamAgent` is the runtime host, `TeamBackend` is the data/message hub.
+- `com.openjiuwen.agentevolving/`: RL-based agent optimization, evaluation,
+  trajectory management, and checkpointing.
+- `com.openjiuwen.autoharness/`: automated testing/evaluation infrastructure
+  — pipelines, orchestrators, stages, and experience management.
+- `com.openjiuwen.extensions/`: optional integrations such as storage
+  (db/kv), checkpointer (redis), context evolver, message queue, sandbox
+  providers, and vendor-specific adapters.
+- `com.openjiuwen.dev_tools/`: developer tooling — agent builder, prompt
+  builder, skill creator/evaluator, tune.
+- `com.openjiuwen.deepagents/`: deep agent framework with middlewares,
+  subagents, and tools.
+- `com.openjiuwen.spi/`: Service Provider Interface for store (kv/object/
+  query/vector) extensions.
+- `src/test/java/`: JUnit 5 tests; `system-test` tagged tests are excluded
+  from normal surefire runs.
+- `examples/` and `documents/`: user-facing usage references. Update them
+  when public behavior changes.
+
+## Instruction Priority
+
+- Follow system, tool, and user instructions first, then this file, then
+  module-local docs.
+- Before changing behavior, inspect the touched module, its exported
+  surface, and nearby tests/examples.
+- Prefer small, targeted diffs. Do not refactor unrelated areas
+  opportunistically.
+
+## Core Architecture
+
+- Treat documented public APIs, examples, and README snippets as public API.
+- Preserve the Card/Config split: cards define identity/metadata
+  (`AgentCard`, `ToolCard`, `WorkflowCard`, `SysOperationCard`); runtime
+  behavior belongs in configs, agents, managers, or resource instances.
+- `com.openjiuwen.core.singleagent` is the current single-agent API.
+  `com.openjiuwen.core.singleagent.legacy` exists for compatibility only.
+- `Runner.resourceMgr` is shared process-global state. Use stable IDs
+  and keep tests isolated.
+- `TeamAgent` is a single implementation serving both Leader and Teammate
+  roles (switched by `TeamRole`). Do not split into two classes.
+- `CoordinatorLoop` does not make decisions; it only handles wake-up and
+  periodic polling. All business logic is in `EventDispatcher` + team tools.
+
+## Commands
+
+- Compile: `mvn compile`
+- Run all unit tests: `mvn test`
+- Run system tests: `mvn test -Dsurefire.groups=system-test`
+- Run targeted test: `mvn test -Dtest=ClassName` or `-Dtest=ClassName#methodName`
+- Skip tests: `mvn compile -DskipTests`
+- Code coverage report: `mvn test jacoco:report`
+- Lint / code check: follow `.claude/rules/coding-standard.md` (Huawei CodeArts Check 102 rules)
+
+`mvn test` excludes `system-test` tagged tests by default (configured in
+surefire plugin `<excludedGroups>`). To run them, pass
+`-Dsurefire.groups=system-test`.
+
+## Java & JDK 17 Notes
+
+- Source and target: Java 17. Use JDK 17 features (records, sealed classes,
+  pattern matching for instanceof, text blocks) where appropriate.
+- Lombok is used (`provided` scope). Do not add Lombok annotations to code
+  that doesn't already use them; prefer explicit code for new files.
+- Jackson 2.17 for JSON. Reuse `ObjectMapper` as singleton; never create
+  per-call.
+- SLF4J 2.0 + Logback 1.5 for logging. Logger must be
+  `private static final` (see `G.LOG.01`/`G.LOG.02`).
+- OkHttp 4.12 for HTTP. Connection pool tuning matters for LLM call
+  throughput (see `.claude/rules/performance-tuning.md`).
+- Do not use `Executors.newCachedThreadPool()` / `newFixedThreadPool()` —
+  create `ThreadPoolExecutor` explicitly with bounded queue and named threads
+  (see `X.CON.06` in coding-standard).
+
+## More Detail
+
+- Coding standards (102 rules): `.claude/rules/coding-standard.md`
+- Performance tuning (JDK 17 baseline): `.claude/rules/performance-tuning.md`
+- Agent Team quick build guide: `.claude/rules/agent-team-guide.md`
+- Workflow application guide: `.claude/rules/workflow-guide.md`
+- Deep operational guides: `.claude/skills/`
+- Permissions and env vars: `.claude/settings.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+@AGENTS.md
+
+# Claude Code Notes
+
+- Keep shared project rules in `AGENTS.md` so all coding agents use the
+  same architecture guidance.
+- Use this file only for Claude-specific imports or workflow notes.
+- Detailed rules by topic: see `.claude/rules/` (coding-standard,
+  performance-tuning, agent-team-guide, workflow-guide).
+- Skills for deep operational guides: see `.claude/skills/`
+  (jvm-troubleshoot, refactor-guide, skill-creator, team-skill-creator,
+  agent-team-guide, workflow-guide, performance-tuning).
+- Permissions, env vars, and model defaults: see `.claude/settings.json`.
+- Run `/memory` to manage auto memory.
+- Run `/context` to see which files are loaded in the current session.


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

# Commit `eaeaeac` 详细描述

**提交信息**: `feat(skill): 添加.claude目录，适配claude code`
**作者**: WeiCheng Tan | **日期**: 2026-07-15 | **变更**: 62 文件，+11,629 行

这是一个纯配置/文档类提交，零业务代码变更。目的是为 `agent-core-java` 仓库建立完整的 Claude Code 适配层，让 Claude Code 在本仓库工作时自动加载项目架构知识、编码规范、操作指南和权限配置。

---

## 一、项目级指导文件（2 个）

### 1. `AGENTS.md` — 跨 AI 编码助手的共享指令

定义了所有 AI 编码助手（不限于 Claude）必须遵守的规则：

- **仓库模块划分**：9 个模块的职责定义
  - `core/` — 公共 SDK/运行时（agent、workflow、session、memory、retrieval、security、sysop）
  - `harness/` — 编码 agent 框架（prompts、rails、tools、subagents、task loop、workspace）
  - `agentteams/` — 多 agent 团队框架（Leader-Teammate 模型）
  - `agentevolving/` — RL 优化、评估、轨迹管理
  - `autoharness/` — 自动化测试/评估基础设施
  - `extensions/` — 可选集成（存储、checkpointer、MQ、sandbox）
  - `dev_tools/` — 开发工具（agent builder、prompt builder、skill creator）
  - `deepagents/` — Deep Agent 框架
  - `spi/` — 服务提供者接口

- **指令优先级**：system/tool/user > AGENTS.md > 模块本地文档

- **核心架构约束**：
  - Card/Config 分离：Card 定义身份/元数据，运行时行为在 Config/Agent/Manager 中
  - `TeamAgent` 单实现双角色（Leader/Teammate 由 `TeamRole` 切换），不要拆成两个类
  - `CoordinatorLoop` 不做决策，只负责唤醒和周期轮询，业务逻辑在 `EventDispatcher` + team tools

- **JDK 17 规范**：Lombok（provided scope，新文件不加注解）、Jackson 2.17（ObjectMapper 单例）、SLF4J 2.0 + Logback 1.5、OkHttp 4.12、禁止 `Executors.newCachedThreadPool/newFixedThreadPool`

### 2. `CLAUDE.md` — Claude Code 专用入口

引用 `@AGENTS.md`，指向 rules/skills/settings 路径，提供 `/memory` 和 `/context` 命令提示。

---

## 二、`.claude/settings.json` — 权限与环境配置

```json
{
  "permissions": {
    "allow": ["Bash(mvn *)", "Bash(mvnw *)", "Bash(java *)", "Bash(javac *)", "Bash(git *)"],
    "deny": ["Read(./.env)", "Read(./.env.*)", "Read(./config/secrets.json)", "Read(./**/secrets/**)", "Read(./**/APIKEY/**)"]
  },
  "language": "chinese",
  "includeGitInstructions": true
}
```

- 允许 mvn/java/git 等构建和版本控制命令自动执行
- 拒绝读取敏感文件（.env、secrets、APIKEY）
- 默认语言中文

---

## 三、`.claude/rules/` — 10 条编码规范规则

### 1. `architecture.md` — 架构约束

定义模块边界、Card/Config 分离原则、TeamAgent 单实现双角色、CoordinatorLoop 职责边界等。核心内容：

- **Public API**：公开类/方法视为 public API，变更需保持兼容，兼容性测试强制 Java-Python 对等
- **Card/Config 分离**：Card 是静态可序列化元数据（跨进程边界），Config 是运行时对象（进程本地）。禁止将 sessionId/runner 等运行时数据放入 Card
- **模块边界表**：12 个包的职责定义，变更前需检查公开接口和附近测试
- **关键规则**：`TeamAgent` 单实现双角色，不拆成两个类

### 2. `coding-standard.md` — 华为 CodeArts Check 124+ 条规则速查

覆盖 18 个主题的速查表：

| 场景 | 适用规则 |
|---|---|
| Service/业务类 | `G.OBJ.01-08`, `G.NAM.03/04`, `G.CMT.01/03` |
| 异常处理 | `G.ERR.01-09`, `G.CTL.03` |
| 多线程代码 | `G.CON.01/05-12`, `G.TYP.03`, `X.CON.01-06` |
| 日志 | `G.LOG.01-04` |
| 集合/泛型 | `G.COL.02-04`, `G.PRM.01`, `X.COL.01-04` |
| IO 操作 | `G.PRM.07`, `G.FIO.01-04`, `G.TYP.09` |
| 方法签名 | `G.MET.01-07`, `G.NAM.04`, `G.ERR.07` |
| 常量/枚举 | `G.NAM.05`, `G.DCL.04/05`, `G.FMT.15` |
| 覆写 equals | `G.OBJ.06`, `G.EXP.04` |
| 可序列化类 | `G.SER.01/02/04/05/07` |
| 测试 | `X.TST.01-06` |
| SQL/数据库 | `X.SQL.01-07` |
| Code Review | 先查 Self-Check List，再按场景查 |

10 条快速自查覆盖 80% 常见问题：PascalCase 类名、camelCase 方法名、ALL_UPPERCASE 常量、无空 catch、不直接捕获 Throwable/Exception、re-throw 传原始 cause、避免空块、用 SLF4J 门面、Logger private static final、覆写 equals 时覆写 hashCode。

### 3. `concurrency.md` — 并发规范

- **三层并发模型不混用**：ThreadPoolExecutor（后台 worker） / CompletableFuture（TeamBackend） / Reactor（BaseAgent/RunnerImpl）
- **ThreadPoolExecutor**：必须用有界队列 + 命名守护线程 + CallerRunsPolicy，禁止 `Executors.newCachedThreadPool/newFixedThreadPool/newSingleThreadExecutor`
- **CompletableFuture**：`.join()` 只允许在同步入口点（dispatchTask/destroyTeam/startup/approvePlan），禁止在 EventBus 事件处理器内
- **Reactor**：在 `Schedulers.boundedElastic()` 上订阅，用 `ReactiveAdapters` 做阻塞→响应式转换
- **EventBus**：单线程循环，所有 handler 串行执行，禁止在 coordination handler 内并行化
- **锁选择**：synchronized（简单生命周期）/ ReentrantLock（细粒度变更）/ volatile（跨线程标志）/ Atomic*（无锁）/ ConcurrentHashMap（共享可变 Map）
- **反模式**：EventBus 内 .join()、Mono.fromFuture 跨层桥接、HashMap 并发写、未命名线程

### 4. `dependency-management.md` — 依赖管理

- **核心规则**：
  - 所有版本用 `${property}`，不硬编码
  - 同族库共享一个版本属性（如 `${jackson.version}`）
  - 禁止重复用途库
  - 依赖 scope 规范：runtime/default、provided（Lombok）、test、optional
  - main 分支禁止 `*-SNAPSHOT` 依赖
  - 插件版本锁定
  - 许可证必须 Apache 2.0 / MIT / BSD-2 / EPL-LGPL 兼容

- **禁止库对照表**：

| 禁止 | 替代 | 原因 |
|---|---|---|
| gson, org.json:json, jsonpath | Jackson | 唯一 JSON 库 |
| Apache HttpClient, java.net.HttpClient | OkHttp | 唯一 HTTP 客户端 |
| commons-io, commons-lang3 | JDK NIO / JDK 17 原生 | 避免 Apache Commons |
| guava | JDK 17 (List.of/Map.of/Optional) | 避免 Guava |
| JUnit 4 | JUnit 5 | 唯一测试框架 |
| hamcrest-core, jsonassert | AssertJ | 唯一断言库 |
| Executors.newCachedThreadPool/newFixedThreadPool | ThreadPoolExecutor | X.CON.06 |
| log4j, java.util.logging 直接 | SLF4J 门面 | G.LOG.01 |
| SimpleDateFormat | DateTimeFormatter | X.CON.01 |

- **Lombok**：provided scope，新文件不加 Lombok 注解，优先显式代码
- **升级和 CVE 检查**：`mvn versions:display-dependency-updates`、`mvn dependency:tree`、`dependency-check-maven:check`

### 5. `error-codes-standard.md` — 错误码标准

- **唯一合法抛异常方式**：所有异常必须通过 `ErrorHelper.raiseError/buildError` + `StatusCode`，禁止裸 `RuntimeException/IllegalStateException/IllegalArgumentException/NullPointerException`
- **StatusCode 与 Exception 类正交**：StatusCode 标识错误（哪个模块、哪种失败），Exception 类编码控制流语义（重试/中止/终止）

| Exception 类 | fatal | recoverable | 语义 |
|---|---|---|---|
| `FrameworkError` | true | false | 基础设施故障，无法继续 |
| `ValidationError` | false | false | 无效输入/配置，重试无意义 |
| `ExecutionError` | false | true | 暂时性失败，重试可能成功 |
| `Termination` | false | false | 非错误的控制流终止 |

- **新增 StatusCode 规则**：
  - 代码范围必须落在对应段（Workflow 100000-100999、Agent 120000-129999 等 14 个段）
  - 命名遵循 `{SCOPE}_{SUBJECT}_{FAILURE_TYPE}`
  - 消息模板用 `{name}` 占位符，禁止 `%s` 或 `+` 拼接
  - 代码值必须唯一
- **禁止事项**：不在业务代码中按 code 分支、不往 StatusCode 塞运行时数据、不在错误路径上抛新异常、不吞异常

### 6. `java-security.md` — Java 安全规范

- **凭证处理**：禁止硬编码密钥，必须从环境变量或运行时配置加载
- **沙箱操作**：`SandboxGateway` 单例入口，禁止绕过路径验证
- **文件路径验证**：`PathChecker` + `Path.normalize()` + `toAbsolutePath()`，解析失败默认拒绝
- **Shell 执行**：`ProcessBuilder` 列表参数，`LocalShellOperation` 双重过滤（allowlist + dangerous patterns）
- **SSRF 防护**：`UrlUtils.checkUrlIsValid()` 阻止内网 IP
- **SSL/TLS**：`SslUtils.createStrictSslContext()` 强制 TLS 1.2+
- **分层安全模型**：

| 层 | 包 | 目的 |
|---|---|---|
| Guardrail | `core.security.guardrail` | 用户输入风险检测 |
| Permission | `harness.security` | ALLOW/ASK/DENY 策略 |
| Security Rail | `harness.rails.security` | 只读模式强制 |
| SysOp Validation | `core.sysop` | Shell 白名单 + 危险模式拦截 |
| Common Security | `core.common.security` | SSRF/SSL/路径敏感性 |

### 7. `json-serialization.md` — JSON 序列化规范

- Jackson 2.17 是唯一 JSON 库，禁止 Gson/org.json/JsonB
- ObjectMapper 必须类级 `static final` 单例，或用 `JsonUtils.getMapper()`
- Card 类依赖 Jackson 默认 bean 序列化，不要加不必要的 `@JsonProperty`
- 日期时间用 `jackson-datatype-jsr310` + `JavaTimeModule`
- 常用注解场景：`@JsonProperty`（键名不同）、`@JsonInclude(NON_NULL)`（省略 null）、`@JsonIgnoreProperties(ignoreUnknown=true)`（容忍未知字段）
- 反模式：方法内 `new ObjectMapper()`、多个相同配置的 ObjectMapper、手动 `toMap()` + ObjectMapper

### 8. `logging.md` — 日志规范

- 使用 `Loggers` 门面，禁止直接 `LoggerFactory.getLogger()`
- 14 个预定义 Logger 字段对应不同模块：

| Logger 字段 | 适用模块 |
|---|---|
| `Loggers.AGENT` | core.singleagent, agentteams.*, dev_tools.tune, agentevolving |
| `Loggers.TOOL` | harness.tools, AbilityManager |
| `Loggers.MULTI_AGENT` | core.multiagent, 层级团队 |
| `Loggers.CONTROLLER` | core.controller, 事件处理 |
| `Loggers.SESSION` | core.session, 流写入, checkpointer |
| `Loggers.LLM` | core.foundation.llm, 模型客户端 |
| `Loggers.SYS_OPERATION` | core.sysop, shell/fs/code |
| ... | 等 14 个 |

- MDC 由 `DefaultLogger` 自动管理，业务代码不调用 `MDC.put/remove`
- 日志级别：debug → info → warning → error → critical → exception
- 自动脱敏：控制字符清理 + 11 个敏感字段脱敏（messages、response_content、arguments、result 等）

### 9. `templates-and-cases.md` — 模板与案例使用指引

- 新建代码从 `.claude/templates/` 对应模板开始
- 修 bug 先查 `.claude/cases/` 相关案例
- 写测试查 `.claude/test-scenarios/` 覆盖场景
- Case vs Test-Scenario 区分：已发生的事故→Case；可能出错的边界→Test-Scenario

### 10. `test-flow.md` — 测试流程规范

- **测试位置**：单元测试镜像源码路径，系统测试在 `core/systemtest/`
- **测试模式**：Unit（隔离逻辑）、Compatibility（Java-Python API 一致性）、System/E2E（完整工作流）
- **测试框架**：JUnit 5 + Mockito 5.2+ + AssertJ 3.25+
- **方法命名**：`methodName_scenario_expected`
- **编程式 Mockito**：`mock()`/`when()`，禁止 `@Mock`/`@InjectMocks` 注解
- **测试标签**：默认跑 unit + compatibility（排除 system-test）
- **响应式测试**：`StepVerifier`（Flux/Mono）、`CompletableFuture.join()` + timeout
- **断言**：AssertJ 流式断言，异常断言用 `assertThatThrownBy()`
- **覆盖率**：JaCoCo 0.8.11，core 和 harness 模块 80% 门槛
- **兼容性测试**：验证 Java-Python API 对等

---

## 四、`.claude/skills/` — 7 个深度操作指南

### 1. `agent-team-guide` — Agent Team 快速构建指南（382 行 SKILL.md + 1 个参考文件）

- **核心心智模型**：Leader-Teammate 模式，Leader 通过 team tools 协调 Teammate，Teammate 各自进入 ReAct 循环
- **场景速查表**：临时团队 vs 持久团队、预定义 vs 动态扩展、inprocess vs process spawn
- **快速开始**：3 种场景的完整代码模板（临时团队、持久团队、带 team skill 的团队）
- **配置参数速查**：lifecycle（temporary/persistent）、teammateMode（build_mode/plan_mode）、spawnMode（inprocess/process）、storage（sqlite/memory/postgresql/mysql）、teamMode（default/predefined/hybrid）、modelPoolStrategy（round_robin/by_model_name）
- **成员状态机**：5 种状态（CREATED→SPAWNED→ACTIVE→IDLE→SHUTDOWN）及转换条件
- **多阶段数据流**：dispatchTask → spawn_member → create_task → claim_task → send_message → complete_task
- **Pitfall FAQ**：12 个高频问题及解决方案（如 `IllegalStateException: Missing required key`、`build()` 需要调用两次、`spawn_member` 后必须 `create_task` 等）
- **子系统速查**：agent/messager/spawn/worktree/teamworkspace/monitor/interaction/tools/database/schema 各子包关键类
- **参考文件**：`MinimalRunnableExample.java` — 自包含最小可运行示例

### 2. `caveman-install` — Caveman 插件安装指南（162 行 SKILL.md）

- Windows/WSL/Claude Code 三种安装方式
- 安装内容：Plugin + Hooks（SessionStart/UserPromptSubmit）+ Statusline + Flag file
- 验证、状态栏配置、模式切换（lite/full/ultra/wenyan）、故障排查、卸载流程

### 3. `coding-standard` — 编码规范完整参考（661 行 SKILL.md）

- 华为 CodeArts Check 102 条规则的完整描述，每条含 OK/BAD 代码示例
- 3 个引擎：fixbotengine-java（91 条质量规则）、codemars（7 条安全规则）、secbrella（4 条安全规则）
- 扩展规则：X.TST（测试）、X.SQL（数据库）、X.CON（并发细节）、X.COL（集合细节）、X.PRM（性能细节）、X.DEP（依赖）

### 4. `jvm-troubleshoot` — JVM 生产故障排查手册（298 行 SKILL.md + 5 个参考文档）

7 类故障按"症状→诊断流程→根因表→修复"组织：

1. **OOM**（堆/非堆/Metaspace/直接内存）
2. **CPU 100%**（用户态/内核态/GC 引起）
3. **高频 GC**（Young GC 频繁/Full GC 频繁/长停顿）
4. **线程死锁**（synchronized/Lock/等待资源）
5. **类加载泄漏**（Metaspace/CGLIB/多 ClassLoader）
6. **模块系统反射失败**（InaccessibleObjectException/--add-opens）
7. **容器内 JVM 问题**（OOMKilled/PID 1/JRE-only/ulimit）

参考文档：

| 文件 | 行数 | 内容 |
|---|---|---|
| `container_troubleshooting.md` | 347 | K8s/Docker 容器 JVM 排查 |
| `diagnostic_commands.md` | 161 | jps/jcmd/jmap/jstack/jstat/top 命令参考 |
| `gc_tuning_guide.md` | 167 | 响应式 GC 排查 |
| `jfr_analysis.md` | 327 | JFR 事后分析（事件类别、启动采集、JMC 分析、配置模板） |
| `troubleshooting_cases.md` | 284 | 4 个端到端案例（堆泄漏→Caffeine、CPU 正则回溯、死锁→锁排序、Metaspace→代理缓存） |

### 5. `performance-tuning` — Java 性能调优指南（407 行 SKILL.md + 7 个参考文档）

- **优化层次**：应用层→JVM 层→OS 层→硬件层
- **决策流**：先度量→定位瓶颈→选优化层→实施→验证
- **JVM 参数调优**：堆/Metaspace/栈/Code Cache/JIT/GC 参数
- **代码级性能**：集合选择、Stream 性能、反射优化（4 级：缓存 Method→MethodHandle→LambdaMetafactory→字节码生成）、锁优化、逃逸分析
- **编译优化**：JIT 分层编译、内联、循环优化、分支预测、去虚化
- **性能测试与 Profiling**：JMH 基准、JFR、async-profiler、Arthas
- **AI Agent 框架优化**：LLM HTTP 调用占 90%+ 时间，OkHttp 连接池、Jackson 流式、MethodHandle、Prompt 拼接

参考文档：

| 文件 | 行数 | 内容 |
|---|---|---|
| `ai_agent_optimization.md` | 459 | AI Agent 框架性能优化（OkHttp 连接池/Jackson 流式/MethodHandle/Prompt 拼接/Caffeine 缓存） |
| `code_level_optimization.md` | 647 | 代码级优化（集合/Stream/反射/锁/逃逸分析/String/JDK 17 新特性） |
| `gc_tuning.md` | 314 | 主动 GC 调优（G1/ZGC/Parallel 选择决策树与参数） |
| `jit_compiler.md` | 493 | JIT 与编译优化（分层编译/内联/循环优化/分支预测/GraalVM 对比） |
| `jmh_profiling.md` | 585 | JMH 基准与 Profiling 工具（JFR/async-profiler/Arthas/VisualVM） |
| `jvm_params.md` | 325 | JVM 参数详解（堆/Metaspace/栈/GC/监控/调试/模块系统） |
| `tuning_cases.md` | 550 | 6 个端到端优化案例（Stream→for 3.7x、HashMap+LongAdder 5.3x、反射→MethodHandle 27x、JVM 参数 P99 300→85ms、逃逸分析失效、ZGC P99 500→80ms） |

### 6. `refactor-guide` — 项目重构规范与流程治理（200 行 SKILL.md + 3 个参考文档）

- **预重构检查清单**：5 项必查（测试覆盖、公共 API、依赖方、回滚方案、文档更新）
- **重构粒度 L1-L4**：L1 方法级→L2 结构级→L3 接口级→L4 架构级
- **标准 5 步流程**：特征测试→小步修改→验证→提交→文档
- **安全重构技术**：Strangler Fig 模式、并行实现、特征测试
- **反模式**：大爆炸重构、无测试重构、重构+新功能混合

参考文档：

| 文件 | 行数 | 内容 |
|---|---|---|
| `legacy_code_patterns.md` | 256 | 遗留代码重构（Seam 概念、特征测试、6 种依赖打破技术） |
| `refactoring_patterns.md` | 340 | 9 种重构手法（Extract Method/Inline/Extract Class/Move Method/条件→多态/Switch→Strategy/参数对象/Temp→Query/解释变量，含 before/after 代码） |
| `refactoring_cases.md` | 333 | 4 个端到端案例（拆 1000 行 Service→5 个 200 行类、静态调用→DI 40→85%、单体→微服务 Strangler Fig 3 月、补测试 0→80%） |

### 7. `team-skill-creator` — Team Skill 生成器（267 行 SKILL.md + 模板 + 示例）

- **生成流程**：确定协作模式→定义角色→设计工作流→绑定工具→声明依赖→自检
- **协作模式分类**：串行流水线、并行分工、协商决策、层级委派
- **5 个文件模板**（含字段注解）：SKILL.md、roles/*.md、workflow.md、bind.md、dependencies.yaml
- **完整示例**：dev_test_parallel（开发者+测试员 2 角色并行模式，含全部 5 个文件的完整内容）
- **生成后自检清单**：8 项检查（kind: team-skill、roles 匹配、5 段式角色文件、Inline Persona 格式、workflow 步骤编号、bind 三段式、dependencies 优雅降级、输出路径格式、角色可见性规则、放置路径提示）

模板文件（5 个）：

| 模板 | 用途 |
|---|---|
| `templates/SKILL.md` | 团队元数据（name/version/kind:team-skill/roles 概览） |
| `templates/role.md` | 角色定义（Identity/Success Criteria/Boundary/Output Schema/Inline Persona） |
| `templates/workflow.md` | 执行脚本（mermaid 流程图 + Step 0~N + Final Report） |
| `templates/bind.md` | 约束（Resource/Behavioral/Failure Handling） |
| `templates/dependencies.yaml` | 依赖声明（skills/tools/global_dependencies） |

### 8. `workflow-guide` — 工作流应用构建指南（321 行 SKILL.md + 4 个参考文档）

- **核心心智模型**：4 层能力分层（图定义→组件编排→执行与会话→应用集成）
- **关键概念速查**：Workflow、WorkflowCard、Nodes/Components、Edges（普通/条件/流式）、WorkflowSessions、WorkflowOutput、WorkflowExecutionState（COMPLETED/INPUT_REQUIRED/ERROR）
- **场景速查**：简单问答、流式输出、交互式追问、条件分支、子工作流、多工作流路由
- **最小工作流示例**：Start→Questioner→End，含 INPUT_REQUIRED 处理
- **invoke vs stream**：同步执行 vs 流式输出
- **Pitfall FAQ**：8 个常见问题

参考文档：

| 文件 | 行数 | 内容 |
|---|---|---|
| `MinimalWorkflowExample.java` | 197 | 自包含最小可运行工作流示例（Start→Questioner→End + INPUT_REQUIRED 处理） |
| `key_concepts.md` | 179 | 关键概念详解（4 层心智模型/Workflow/WorkflowCard/Edges/Sessions/Output/State/Streaming） |
| `components_guide.md` | 250 | 组件配置指南（Start/End/Questioner/LLM/Branch/SubWorkflow/自定义 + 边配对规则 + Schema 语法） |
| `workflow_cases.md` | 377 | 4 个端到端案例（金融助手多工作流、流式 Q&A、表单填写、条件分支） |

---

## 五、`.claude/templates/` — 6 个代码/文档模板

### 1. `card.java.tmpl` — Card 类模板

继承 `BaseCard`，使用 Lombok @Data/@Builder，包含 `toolInfo()` 方法和手写 Builder 继承 `BaseCard.Builder`。占位符：`{{CardName}}`。

### 2. `service.java.tmpl` — Service/业务类模板

继承 `BaseAgent`，包含 ErrorHelper + StatusCode 错误处理、Loggers 日志、ConcurrentHashMap 共享状态、null 输入校验。占位符：`{{ClassName}}`、`{{ConfigClass}}`、`{{StatusCode}}`、`{{Logger}}`。

### 3. `tool.java.tmpl` — Harness 工具模板

纯 POJO 无框架注解，permissionMode 参数，ToolOutput.builder() 返回，包含 InjectionCheck record。占位符：`{{ToolName}}`、`{{Logger}}`。

### 4. `test.java.tmpl` — JUnit 5 单元测试模板

@Nested 分组，AssertJ assertThat/assertThatThrownBy，编程式 Mockito mock()/when()，包私有类。占位符：`{{ClassName}}`、`{{TargetClass}}`、`{{ConfigClass}}`。

### 5. `exception.md.tmpl` — 新增 StatusCode 条目模板

4 步流程：加枚举（按范围段）→验唯一→加兼容测试→使用 ErrorHelper。包含 14 个代码范围段对照表。

### 6. `README.md` — 模板使用说明

统一约定：华为版权头、Javadoc 方法名摘要、Loggers 日志、ObjectMapper static final、ConcurrentHashMap、ErrorHelper + StatusCode、Lombok 仅用于 Card 子类。

---

## 六、`.claude/test-scenarios/` — 3 个测试场景

### 001: 公共方法 null 输入必须抛 BaseError

- **优先级**：P0 | **类型**：null
- **内容**：4 种 null/空输入条件，期望 BaseError + StatusCode，禁止裸 NullPointerException
- **覆盖**：ControllerAgent 部分已覆盖 [x]，BashTool 未覆盖 [ ]

### 002: 共享 Map 并发写必须用 ConcurrentHashMap

- **优先级**：P0 | **类型**：concurrency
- **内容**：10 线程并发注册+读取，期望无死循环/无 ConcurrentModificationException/无数据丢失
- **覆盖**：未覆盖 [ ]

### 003: ObjectMapper 必须类级 static final

- **优先级**：P0 | **类型**：resource
- **内容**：检查所有 `new ObjectMapper()` 位置，区分类级声明（合规）vs 方法内创建（违规）
- **覆盖**：未覆盖 [ ]

场景文件统一格式：id、title、module、priority、type、tags、Description、Input Conditions、Expected Behavior、Test Location、Coverage 状态。

---

## 七、总结

这个 commit 的核心价值是**将项目隐性的架构知识、编码规范和操作经验显性化**，通过 Claude Code 的 `.claude/` 目录结构注入到 AI 编码助手的工作上下文中。具体来说：

1. **`AGENTS.md` + `CLAUDE.md`**：让任何 AI 编码助手一进入仓库就理解模块划分、架构约束和指令优先级
2. **`settings.json`**：预设安全的权限边界（允许构建命令、拒绝敏感文件读取）
3. **10 条 rules**：覆盖架构、编码规范、并发、依赖、错误码、安全、JSON、日志、模板、测试——这些是日常编码中最常需要查阅的规范
4. **7 个 skills**：提供深度操作指南，从 Agent Team 构建、JVM 排查、性能调优到重构治理，每个 skill 都有完整的参考文档和端到端案例
5. **6 个 templates**：标准化新建代码的脚手架，确保风格一致
6. **3 个 test-scenarios**：建立边界条件和错误路径的回归网

**文件统计**：

| 类别 | 文件数 | 总行数 |
|---|---|---|
| 项目指导文件（AGENTS.md + CLAUDE.md） | 2 | 118 |
| settings.json | 1 | 22 |
| rules/ | 10 | ~1,000 |
| skills/ SKILL.md | 8 | ~2,700 |
| skills/ references/ | 20 | ~6,800 |
| templates/ | 6 | ~416 |
| test-scenarios/ | 4 | ~222 |
| **合计** | **62** | **~11,629** |